### PR TITLE
Single value ReferenceFields' setters fail when a list sent as a value 

### DIFF
--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -472,7 +472,7 @@ class ProxyFieldManager(ATFieldManager):
     def get_proxy_object(self, instance):
         """Get the proxy object of the field
         """
-        return self.field._get_proxy(instance)
+        return self.field.get_proxy(instance)
 
     def get_proxy_field(self, instance):
         """Get the proxied field of this field

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -440,10 +440,12 @@ class ReferenceFieldManager(ATFieldManager):
             ref.append(api.get_object_by_path(value))
 
         # Handle non multi valued fields
-        if not self.multi_valued and len(ref) > 1:
-            raise ValueError("Multiple values given for single valued field {}"
-                             .format(self.field))
-
+        if not self.multi_valued:
+            if len(ref) > 1:
+                raise ValueError("Multiple values given for single valued "
+                                 "field {}".format(self.field))
+            else:
+                ref = ref[0]
         return self._set(instance, ref, **kw)
 
     def json_data(self, instance, default=None):


### PR DESCRIPTION
**Current behavior**
When a list or a tuple containing one object is sent to `ReferenceField`s setter, it does not do anything.

**Expected behavior after this PR**
`ReferenceField` setter handles list or tuple of the single element and set it properly.  