### PR TITLE
Fix Travis CI

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -848,8 +848,9 @@ def get_contents(brain_or_object):
     # It may happen when children belong to different catalogs and not
     # found on 'portal_catalog'.
     ret = filter(lambda obj: api.is_object(obj),
-                  api.get_object(brain_or_object).objectValues())
+                 api.get_object(brain_or_object).objectValues())
     return ret
+
 
 def get_parent(brain_or_object):
     """Locate the parent object of the content/catalog brain

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -65,7 +65,7 @@ class ZopeSchemaFieldManager(object):
             return self.field.set(instance, value)
         except WrongType:
             logger.warn("WrongType: Field={} Value={}".format(self.field, value))
-        except:
+        except:  # noqa
             logger.warn("Unknown Exception: Field={} Value={}".format(self.field, value))
 
     def _get(self, instance, **kw):

--- a/travis.cfg
+++ b/travis.cfg
@@ -27,7 +27,8 @@ bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
 [versions]
 Plone = 4.3.15
 zc.buildout =
-setuptools =
+# Fix Error: Wheels are not supported
+setuptools = 36.8.0
 CairoSVG = 1.0.20
 Sphinx = 1.1.3
 zc.recipe.egg = 1.3.2

--- a/travis.cfg
+++ b/travis.cfg
@@ -28,7 +28,7 @@ bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
 Plone = 4.3.15
 # Fix Error: Wheels are not supported
 zc.buildout = 2.10.0
-setuptools = 36.8.0
+setuptools =
 CairoSVG = 1.0.20
 Sphinx = 1.1.3
 zc.recipe.egg = 1.3.2

--- a/travis.cfg
+++ b/travis.cfg
@@ -26,8 +26,8 @@ bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
 
 [versions]
 Plone = 4.3.15
-zc.buildout =
 # Fix Error: Wheels are not supported
+zc.buildout = 2.10.0
 setuptools = 36.8.0
 CairoSVG = 1.0.20
 Sphinx = 1.1.3

--- a/travis.cfg
+++ b/travis.cfg
@@ -28,6 +28,7 @@ bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
 Plone = 4.3.15
 # Fix Error: Wheels are not supported
 zc.buildout = 2.10.0
+five.pt = 2.2.4
 setuptools =
 CairoSVG = 1.0.20
 Sphinx = 1.1.3


### PR DESCRIPTION
Travis CI fails with the following error:

```
handler in zc.buildout.easy_install.UNPACKERS
While:
  Installing.
  Loading extensions.
  Getting distribution for 'mr.developer==1.37'.
Error: Wheels are not supported
```

This is because newer versions of `setuptools` fetch wheels instead of eggs, which buildout does not like