### PR TITLE
Skip objects without workflows

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -470,6 +470,8 @@ def get_workflow_info(brain_or_object, endpoint=None):
 
         # get the status info of the current state (dictionary)
         info = wf_tool.getStatusOf(workflow.getId(), obj)
+        if info is None:
+            continue
 
         # get the current review_status
         review_state = info.get("review_state", None)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When retrieving the status info of objects that have no workflow (the front page is the one causing this bug) the expression 
```python
        info = wf_tool.getStatusOf(workflow.getId(), obj)
```
results in `info` being `None` (should be a `dict`), which causes the fetching process to fail afterwards when trying to retrieve values from `info`:
```python
        review_state = info.get("review_state", None)
        inactive_state = info.get("inactive_state", None)
        cancellation_state = info.get("cancellation_state", None)
        worksheetanalysis_review_state = info.get("worksheetanalysis_review_state", None)
```

## Current behavior before PR

The fetching process fails.

## Desired behavior after PR is merged

Fetching process finishes without errors and having fetched properly all the data from the source instance.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html