### PR TITLE
Import mail settings

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -11,10 +11,13 @@ from Products.ZCatalog.Lazy import LazyMap
 from Acquisition import ImplicitAcquisitionWrapper
 
 from zope.schema import getFields
+from zope.schema import getFieldNames
 
 from plone import api as ploneapi
 from plone.jsonapi.core import router
 from plone.behavior.interfaces import IBehaviorAssignable
+from plone.app.controlpanel.mail import IMailSchema
+
 
 from senaite import api
 from senaite.jsonapi import logger
@@ -1447,6 +1450,21 @@ def get_registry_records_by_keyword(keyword=None):
         elif keyword.lower() in record.lower():
             found_registers[record] = api.get_registry_record(record)
     return found_registers
+
+
+def get_mail_settings():
+    mail_settings = {}
+    portal = api.get_portal()
+    mail_settings_fields = getFieldNames(IMailSchema)
+    for setting in mail_settings_fields:
+        value = portal.getProperty(setting)
+        if value:
+            mail_settings[setting] = value
+
+    mail_settings.update(vars(ploneapi.portal.get_tool(name='MailHost')))
+
+    return mail_settings
+
 
 # -----------------------------------------------------------------------------
 #   Batching Helpers

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1453,14 +1453,19 @@ def get_registry_records_by_keyword(keyword=None):
 
 
 def get_mail_settings():
+    """ Get the mail controlpanel configuration values
+    :return: Dictionary mapping mail parameter name to its current value.
+    """
     mail_settings = {}
     portal = api.get_portal()
     mail_settings_fields = getFieldNames(IMailSchema)
+    # Here we get the values for Site 'From' name (email_from_name)
+    # and Site 'From' address (email_from_address)
     for setting in mail_settings_fields:
         value = portal.getProperty(setting)
         if value:
             mail_settings[setting] = value
-
+    # Get the rest of values from the mail host (ESMTP and SMTP values)
     mail_settings.update(vars(ploneapi.portal.get_tool(name='MailHost')))
 
     return mail_settings

--- a/src/senaite/jsonapi/v1/routes/mailsettings.py
+++ b/src/senaite/jsonapi/v1/routes/mailsettings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from senaite.jsonapi import api
 from senaite.jsonapi import request as req
 from senaite.jsonapi.v1 import add_route

--- a/src/senaite/jsonapi/v1/routes/mailsettings.py
+++ b/src/senaite/jsonapi/v1/routes/mailsettings.py
@@ -1,0 +1,26 @@
+from senaite.jsonapi import api
+from senaite.jsonapi import request as req
+from senaite.jsonapi.v1 import add_route
+
+
+@add_route("/mailsettings", "senaite.jsonapi.v1.mailsettings", methods=["GET"])
+def get(context, request):
+    """Return the mail configuration
+    """
+    mail_settings = api.get_mail_settings()
+
+    # Prepare batch
+    size = req.get_batch_size()
+    start = req.get_batch_start()
+    batch = api.make_batch(mail_settings, size, start)
+
+    return {
+        "pagesize": batch.get_pagesize(),
+        "next": batch.make_next_url(),
+        "previous": batch.make_prev_url(),
+        "page": batch.get_pagenumber(),
+        "pages": batch.get_numpages(),
+        "count": batch.get_sequence_length(),
+        "items": [mail_settings],
+        "url": api.url_for("senaite.jsonapi.v1.mailsettings"),
+    }


### PR DESCRIPTION
**Note**: Supersed by #14 

Related PR: https://github.com/senaite/senaite.sync/pull/10

## Description of the issue/feature this PR addresses

Provide a route for querying the mail settings of the instance as well as a method to retrieve them. The full list of settings that are retrieved is:
```
__ac_local_roles__
email_from_address
email_from_name
force_tls
id
smtp_host
smtp_port
smtp_pwd
smtp_queue
smtp_queue_directory
smtp_uid
title
```
Which correspond mainly to the mail settings that can be observed in the mail settings view:

![mail_config](https://user-images.githubusercontent.com/9968427/34765200-308939b4-f5f1-11e7-8d26-41f2bc28783e.png)
  
## Current behavior before PR

Query and retrieval of mail settings was not possible. 

## Desired behavior after PR is merged

Mail settings can be queried and retrieved. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html

  