### PR TITLE
Add support for querying uid_catalog

### DIFF
--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -25,12 +25,14 @@ class Catalog(object):
         self._bika_catalog = api.get_tool("bika_catalog")
         self._bika_analysis_catalog = api.get_tool("bika_analysis_catalog")
         self._bika_setup_catalog = api.get_tool("bika_setup_catalog")
+        self._uid_catalog = api.get_tool("uid_catalog")
 
         self._catalogs = {
             "portal_catalog": self._catalog,
             "bika_catalog": self._bika_catalog,
             "bika_analysis_catalog": self._bika_analysis_catalog,
             "bika_setup_catalog": self._bika_setup_catalog,
+            'uid_catalog': self._uid_catalog
         }
 
     def search(self, query):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add support for querying `uid_catalog` through the API.

## Current behavior before PR

`uid_catalog` could not be queried.

## Desired behavior after PR is merged

`uid_catalog` can be queried.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html