### PR TITLE
Skip relationship objects when querying uid catalog.

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -271,6 +271,12 @@ def get_info(brain_or_object, endpoint=None, complete=False):
             return {}
         complete = True
 
+    # When querying uid catalog we have to be sure that we skip the objects
+    # used to relate two or more objects
+    if api.is_relationship_object(brain_or_object):
+        logger.warn("Skipping relationship object {}".format(brain_or_object))
+        return {}
+    
     # extract the data from the initial object with the proper adapter
     info = IInfo(brain_or_object).to_dict()
 


### PR DESCRIPTION
Related P.R: https://github.com/senaite/senaite.api/pull/6 (Should be merged before this one).

## Description of the issue/feature this PR addresses

When querying `uid_catalog` with, for example:

`http://localhost:8080/senaite/API/senaite/v1/search?catalog=uid_catalog&limit=600`

an error was raised with the following **Traceback**:

```python
Traceback (most recent call last):
  File "/home/juan/Dev/sync/source/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 24, in decorator
    return f(*args, **kwargs)
  File "/home/juan/Dev/sync/source/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 60, in to_json
    return self.dispatch()
  File "/home/juan/Dev/sync/source/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 54, in dispatch
    return router(self.context, self.request, path)
  File "/home/juan/Dev/sync/source/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/router.py", line 138, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/v1/routes/content.py", line 89, in search
    return api.get_batched()
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 81, in get_batched
    complete=complete)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 1477, in get_batch
    endpoint, complete=complete),
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 246, in make_items_for
    return map(extract_data, brains_or_objects)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 241, in extract_data
    info = get_info(brain_or_object, endpoint=endpoint, complete=complete)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 286, in get_info
    parent = get_parent_info(brain_or_object)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 356, in get_parent_info
    portal_type = get_portal_type(parent)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 934, in get_portal_type
    return api.get_portal_type(brain_or_object)
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.api/src/senaite/api/__init__.py", line 275, in get_portal_type
    fail("{} is not supported.".format(repr(brain_or_object)))
  File "/home/juan/Dev/sync/source/zinstance/src/senaite.api/src/senaite/api/__init__.py", line 159, in fail
    raise SenaiteAPIError("{}".format(msg))
SenaiteAPIError: <Folder at /senaite/bika_setup/bika_departments/department-4/at_references> is not supported.
``` 

We diagnosed this was due to the relationship objects indexed in `uid_catalog`. Since they are not needed in the target instance (they will be automatically created) we have decided to skip them. 

## Current behavior before PR

When querying `uid_catalog` an error was raised with the previous Traceback.

## Desired behavior after PR is merged

`uid_catalog` can be queried without errors. (Relationship objects are skipped.)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html