### PR TITLE
Get full path for brains retrieved from uid catalog

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -271,6 +271,12 @@ def get_info(brain_or_object, endpoint=None, complete=False):
             return {}
         complete = True
 
+    # When querying uid catalog we have to be sure that we skip the objects
+    # used to relate two or more objects
+    if api.is_relationship_object(brain_or_object):
+        logger.warn("Skipping relationship object {}".format(brain_or_object))
+        return {}
+    
     # extract the data from the initial object with the proper adapter
     info = IInfo(brain_or_object).to_dict()
 

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -274,7 +274,7 @@ def get_info(brain_or_object, endpoint=None, complete=False):
     # When querying uid catalog we have to be sure that we skip the objects
     # used to relate two or more objects
     if api.is_relationship_object(brain_or_object):
-        logger.warn("Skipping relationship object {}".format(brain_or_object))
+        logger.warn("Skipping relationship object {}".format(repr(brain_or_object)))
         return {}
     
     # extract the data from the initial object with the proper adapter

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -129,11 +129,6 @@ class ZCDataProvider(Base):
         # extract the metadata
         self.keys = catalog_adapter.get_schema()
 
-        # add specific catalog brain mappings
-        self.attributes.update({
-            "path": "getPath",
-        })
-
         # ignore some metadata values, which we already mapped
         self.ignore = [
             'CreationDate',
@@ -161,6 +156,16 @@ class ZCDataProvider(Base):
         """
         path = self.context.getPath().split("/")
         return "/".join(path[:-1])
+
+
+    def _x_get_physical_path(self):
+        """Generate the physical path
+        """
+        path = self.context.getPath()
+        portal_path = api.get_path(api.get_portal())
+        if portal_path not in path:
+            return "{}/{}".format(portal_path, path)
+        return "/".join(path)
 
 
 class DexterityDataProvider(Base):

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -154,9 +154,8 @@ class ZCDataProvider(Base):
     def _x_get_parent_path(self):
         """Generate the parent path
         """
-        path = self.context.getPath().split("/")
+        path = self._x_get_physical_path().split("/")
         return "/".join(path[:-1])
-
 
     def _x_get_physical_path(self):
         """Generate the physical path


### PR DESCRIPTION
Accept after P.R: #12 

## Description of the issue/feature this PR addresses

The path of the brains obtained from a query to `uid_catalog` did not contain the portal (site) name. However, this info is needed when we want to get the object.  

## Current behavior before PR

The path didn't include the portal (site) name.

## Desired behavior after PR is merged

The path includes the portal (site) name.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html