### PR TITLE
Add function to check if a brain or an object is a relationship object

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -273,7 +273,7 @@ def get_info(brain_or_object, endpoint=None, complete=False):
 
     # When querying uid catalog we have to be sure that we skip the objects
     # used to relate two or more objects
-    if api.is_relationship_object(brain_or_object):
+    if is_relationship_object(brain_or_object):
         logger.warn("Skipping relationship object {}".format(repr(brain_or_object)))
         return {}
     

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1457,6 +1457,16 @@ def get_registry_records_by_keyword(keyword=None):
     return found_registers
 
 
+def is_relationship_object(brain_or_object):
+    """Checks if the passed in brain or object is a relationship object
+
+    :param brain_or_object: A single catalog brain or content object
+    :return: True if the object is a relationship object
+    """
+    if 'at_references' in brain_or_object.getPath():
+        return True
+    return False
+
 # -----------------------------------------------------------------------------
 #   Batching Helpers
 # -----------------------------------------------------------------------------

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1463,7 +1463,7 @@ def is_relationship_object(brain_or_object):
     :param brain_or_object: A single catalog brain or content object
     :return: True if the object is a relationship object
     """
-    if 'at_references' in brain_or_object.getPath():
+    if 'at_references' in get_path(brain_or_object):
         return True
     return False
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add the function 'is_relationship_object' to the JSON API since it is the only place where it is required. This function, as it name suggests, provides the functionality of checking if a brain or object is a relationship object. 

It is useful when the JSON API works as a data provider for `senaite.sync` since this objects will automatically be created in the target instance and hence don't have to be fetched nor imported. 

**Technical note**: The function that was defined in `senaite.api` is slightly different from the one impemented in this PR. The one from `senaite.api` looked like:
```python
def is_relationship_object(brain_or_object):
    """Checks if the passed in brain or object is a relationship object

    :param brain_or_object: A single catalog brain or content object
    :return: True if the object is a relationship object
    """
    parent = get_parent(brain_or_object)
    if hasattr(parent, 'id') and parent.id == "at_references":
        return True
    return False
```
While the one in this PR is:
```python
def is_relationship_object(brain_or_object):
    """Checks if the passed in brain or object is a relationship object

    :param brain_or_object: A single catalog brain or content object
    :return: True if the object is a relationship object
    """
    if 'at_references' in get_path(brain_or_object):
        return True
    return False
```

This modification is due to:
1. I think it is safer and less prone to errors to perform the check using only the given brain or object, without relying on other objects.
2. The first implementation was raising an error (actually #13  solves this problem) when using it on some of the brains from `uid_catalog`. Since the portal path was not included in the brain's path for objects such as `clients` we weren't able to get its parent. 

## Current behavior before PR

The JSON API didn't provide the functionality of checking if an object was a relationship object. Instead, this functionality was living in `senaite.api`.

## Desired behavior after PR is merged

The `is_relationship_object` check can be performed directly from the JSON API without having to call a function from `senaite.api`. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html