### PR TITLE
Add API URLs to settings

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1508,12 +1508,14 @@ def get_settings_by_keyword(keyword=None):
         for key, ischemas in CONTROLPANEL_INTERFACE_MAPPING.items():
             settings_from_ifaces = map(get_settings_from_interface, ischemas)
             settings_from_key = {k: v for d in settings_from_ifaces for k, v in d.items()}
-            settings.append({key: settings_from_key})
+            settings.append({key: settings_from_key,
+                             "api_url": url_for("senaite.jsonapi.v1.settings", key=key)})
         return settings
     # if keyword has value then get only the settings associated to the key
     settings_from_ifaces = map(get_settings_from_interface, CONTROLPANEL_INTERFACE_MAPPING[keyword])
     settings_from_key = {k: v for d in settings_from_ifaces for k, v in d.items()}
-    settings.append({keyword: settings_from_key})
+    settings.append({keyword: settings_from_key,
+                     "api_url": url_for("senaite.jsonapi.v1.settings", key=keyword)})
     return settings
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Related issue: #16 

When navigating to the whole list of settings (`/@/v1/settings`) each particular group settings does not contain API URLs to access them directly, e.g.

`/@/v1/settings/ram`

## Current behavior before PR

Settings don't contain an API URL key `api_url` to navigate to that setting directly.

## Desired behavior after PR is merged

Settings contain, similar to the content routes, an API URL key `api_url` to navigate to that setting directly.

## Screenshot (optional)

![selection_007](https://user-images.githubusercontent.com/9968427/35438666-b2a70ab8-0297-11e8-9e3a-5891d9128e03.png)


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
