### PR TITLE
Added condition for the fields come from Senaite Core.

### DIFF
--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -132,12 +132,13 @@
           factory=".fieldmanagers.ProxyFieldManager"
           />
   </configure>
-
-  <!-- Adapter for Bika LIMS AR Analyses Field -->
-  <adapter
-      for="bika.lims.interfaces.IARAnalysesField"
-      factory=".fieldmanagers.ARAnalysesFieldManager"
-      />
+  <configure zcml:condition="installed senaite.core">
+      <!-- Adapter for Bika LIMS AR Analyses Field -->
+      <adapter
+          for="bika.lims.interfaces.IARAnalysesField"
+          factory=".fieldmanagers.ARAnalysesFieldManager"
+          />
+  </configure>
 
   <!-- Adapter for Reference Field -->
   <adapter

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -126,10 +126,12 @@
       />
 
   <!-- Adapter for Bika LIMS Proxy Field -->
-  <adapter
-      for="bika.lims.interfaces.IProxyField"
-      factory=".fieldmanagers.ProxyFieldManager"
-      />
+  <configure zcml:condition="installed senaite.core">
+      <adapter
+          for="bika.lims.interfaces.IProxyField"
+          factory=".fieldmanagers.ProxyFieldManager"
+          />
+  </configure>
 
   <!-- Adapter for Bika LIMS AR Analyses Field -->
   <adapter
@@ -144,11 +146,12 @@
       />
 
   <!-- Adapter for UIDReference Field -->
-  <adapter
-      for="bika.lims.interfaces.field.IUIDReferenceField"
-      factory=".fieldmanagers.UIDReferenceFieldManager"
-      />
-
+  <configure zcml:condition="installed senaite.core">
+      <adapter
+          for="bika.lims.interfaces.field.IUIDReferenceField"
+          factory=".fieldmanagers.UIDReferenceFieldManager"
+          />
+  </configure>
 
   <!-- ZOPE SCHEMA FIELD MANAGERS
        Field level interface to get and set values and get a JSON compatible


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
https://github.com/senaite/senaite.jsonapi/issues/18
There are some fields that come from *Senaite Core* which are not found in older versions of `Bika Lims`.
## Current behavior before PR
Running Instance fails because of missing classes. 
## Desired behavior after PR is merged
Instance runs as expected.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
