### PR TITLE
Fix path attribute for objects

### DIFF
--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -164,7 +164,7 @@ class ZCDataProvider(Base):
         portal_path = api.get_path(api.get_portal())
         if portal_path not in path:
             return "{}/{}".format(portal_path, path)
-        return "/".join(path)
+        return path
 
 
 class DexterityDataProvider(Base):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Linked issue: #20 
The path info for objects is not correctly calculated.

## Current behavior before PR

Paths are returned like this: `//s/e/n/a/i/t/e///w/o/r/k/s/h/e/e/t/s///W/S/-/0/1/1`

This is due to the method `_x_get_physical_path` returning `"/".join(path)` and `path` being a string containing the path instead of a list.

## Desired behavior after PR is merged

Paths are returned correctly, i.e without slashes between letters.

## Screenshot (optional)
![selection_005](https://user-images.githubusercontent.com/9968427/35796381-a8effada-0a5c-11e8-938f-dba298a5aec1.png)


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
