### PR TITLE
Null values are saved as 'NOW' in Date Time Fields

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,7 @@
 
 **Fixed**
 
+- #25 Null values are saved as 'NOW' in Date Time Fields
 - Fixed Tests
 
 **Security**

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -84,7 +84,7 @@ class DatetimeFieldManager(ZopeSchemaFieldManager):
     interface.implements(IFieldManager)
 
     def set(self, instance, value, **kw):
-        if isinstance(value, basestring):
+        if value and isinstance(value, basestring):
             value = dateutil.parser.parse(value)
         self.field.validate(value)
         return self.field.set(instance, value)
@@ -326,12 +326,13 @@ class DateTimeFieldManager(ATFieldManager):
     def set(self, instance, value, **kw):
         """Converts the value into a DateTime object before setting.
         """
-        try:
-            value = DateTime(value)
-        except SyntaxError:
-            logger.warn("Value '{}' is not a valid DateTime string"
-                        .format(value))
-            return False
+        if value:
+            try:
+                value = DateTime(value)
+            except SyntaxError:
+                logger.warn("Value '{}' is not a valid DateTime string"
+                            .format(value))
+                return False
 
         self._set(instance, value, **kw)
 


### PR DESCRIPTION
## Current behavior before PR
Setters of DateTimeFieldManager and DatetimeFieldManager always tries to convert the incoming value to DateTime/datetime types. It is a problem when incoming value is `None` or an empty string. Then values are set as _NOW_.

## Desired behavior after PR is merged
Null values are saved as `None` in `DateTimeField`s.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
