### PR TITLE
API does not have Calculate Delta Date function.

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -776,6 +776,23 @@ def is_path(path):
         return False
     return True
 
+def calculate_delta_date(literal):
+    """Calculate the date in the past from the given literal
+    :param literal: A date literal, e.g. "today"
+    :type literal: str
+    :returns: Date between the literal and today
+    :rtype: DateTime
+    """
+    mapping = {
+        "today": 0,
+        "yesterday": 1,
+        "this-week": 7,
+        "this-month": 30,
+        "this-year": 365,
+    }
+    today = DateTime(DateTime().Date())  # current date without the time
+    return today - mapping.get(literal, 0)
+
 
 def is_json_serializable(thing):
     """Checks if the given thing can be serialized to JSON


### PR DESCRIPTION
## Current behavior before PR
'calculate_delta_date' function is missing.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
