### PR TITLE
Allow the creation of sample via JSON.API

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -132,7 +132,6 @@ def create_items(portal_type=None, uid=None, endpoint=None, **kw):
         - `parent_uid`  specifies the *uid* of the target folder
         - `parent_path` specifies the *physical path* of the target folder
     """
-
     # disable CSRF
     req.disable_csrf_protection()
 
@@ -1358,6 +1357,7 @@ def create_object(container, portal_type, **data):
             data = u.omit(data, "SampleType", "Analyses")
             # Set the container as the client, as the AR lives in it
             data["Client"] = container
+            return obj
         # Standard content creation
         else:
             # we want just a minimun viable object and set the data later
@@ -1387,21 +1387,7 @@ def create_analysisrequest(container, **data):
     """
     container = get_object(container)
     request = req.get_request()
-    # we need to resolve the SampleType to a full object
-    sample_type = data.get("SampleType", None)
-    if sample_type is None:
-        fail(400, "Please provide a SampleType")
-
-    # TODO We should handle the same values as in the DataManager for this field
-    #      (UID, path, objects, dictionaries ...)
-    results = search(portal_type="SampleType", title=sample_type)
-
-    values = {
-        "Analyses": data.get("Analyses", []),
-        "SampleType": results and get_object(results[0]) or None,
-    }
-
-    return create_ar(container, request, values)
+    return create_ar(container, request, data)
 
 
 def update_object_with_data(content, record):

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -219,7 +219,10 @@ def get_request_data():
         from plone.jsonapi.routes.exceptions import APIError
         raise APIError(400, "Request Data is not JSON deserializable – Check JSON Syntax!")
     out_data = json.loads(data)
+
+    # When using requests.post, the data is stored as a dict in request.form
     out_data.update(request.form)
+
     out_data = _.convert(out_data, _.to_list)
     return out_data
 

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -218,7 +218,10 @@ def get_request_data():
     if not is_json_deserializable(data):
         from plone.jsonapi.routes.exceptions import APIError
         raise APIError(400, "Request Data is not JSON deserializable – Check JSON Syntax!")
-    return _.convert(json.loads(data), _.to_list)
+    out_data = json.loads(data)
+    out_data.update(request.form)
+    out_data = _.convert(out_data, _.to_list)
+    return out_data
 
 
 def get_json():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This pull request makes possible to create Samples (aka "AnalysisRequest") with JSON.API.

Below a python script that create an Analysis Request sing the JSON.API:

```python
import requests


HOST_URL = "http://localhost:8080/senaite"


def create_sample(session, data):
    client_uid = data.get("Client")
    url = "{}/@@API/senaite/v1/AnalysisRequest/create/{}".format(HOST_URL, client_uid)
    session.post(url, data=data)


def get_session(user, password):
    session = requests.Session()
    session.auth = (user, password)
    url = "{}/@@API/senaite/v1/auth".format(HOST_URL)
    response = session.get(url)
    if response.status_code == 200:
        session = None
    return session


if __name__ == "__main__":

    user = "username"
    password = "password"

    data = {
        "Client": "<client_uid>",
        "Contact": "<client_contact_uid>",
        "SampleType": "<sample_type_uid>",
        "DateSampled": "2020-03-19 15:56:20",
    }   

    # Get an authenticated session
    session = get_session(user, password)
    if not session:
        print "Cannot authenticate"
    else:
        # Create the Sample
        create_sample(session, data)
```

## Current behavior before PR

Is not possible to create an Analysis Request with JSON.API

## Desired behavior after PR is merged

Possibility to create an Analysis Request with JSON.API

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
