### PR TITLE
Make senaite.jsonapi catalog-agnostic on searches

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,8 @@
+1.2.3 (unreleased)
+------------------
+
+- #34 Make senaite.jsonapi catalog-agnostic on searches
+
 1.2.2 (2020-03-03)
 ------------------
 

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -18,8 +18,10 @@
 # Copyright 2017-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+
 from bika.lims import api as senaiteapi
 from DateTime import DateTime
+from Products.CMFPlone.CatalogTool import CatalogTool
 from senaite.jsonapi import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import request as req
@@ -36,25 +38,12 @@ class Catalog(object):
     interface.implements(ICatalog)
 
     def __init__(self, context):
-        self._portal_catalog = api.get_tool("portal_catalog")
-        self._bika_catalog = api.get_tool("bika_catalog")
-        self._bika_analysis_catalog = api.get_tool("bika_analysis_catalog")
-        self._bika_setup_catalog = api.get_tool("bika_setup_catalog")
-        self._uid_catalog = api.get_tool("uid_catalog")
-
-        self._catalogs = {
-            "portal_catalog": self._portal_catalog,
-            "bika_catalog": self._bika_catalog,
-            "bika_analysis_catalog": self._bika_analysis_catalog,
-            "bika_setup_catalog": self._bika_setup_catalog,
-            "uid_catalog": self._uid_catalog
-        }
+        self._catalogs = {}
 
     def search(self, query):
         """search the catalog
         """
         logger.info("Catalog query={}".format(query))
-
         # Support to set the catalog as a request parameter
         catalogs = _.to_list(req.get("catalog", None))
         if catalogs:
@@ -67,6 +56,11 @@ class Catalog(object):
 
     def get_catalog(self):
         name = req.get("catalog", "portal_catalog")
+        if name not in self._catalogs:
+            # Get the catalog directly from senaite api
+            cat = senaiteapi.get_tool(name)
+            if isinstance(cat, CatalogTool):
+                self._catalogs[name] = cat
         return self._catalogs[name]
 
     def get_schema(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.jsonapi` only supports a subset of catalogs from SENAITE. With this Pull Request, `senaite.jsonapi` becomes catalog-agnostic by delegating the resolution of the proper catalog on searches to core's api.

## Current behavior before PR

Cannot search against some catalogs.

## Desired behavior after PR is merged

Can search for any catalog, even if is a new catalog not specifically added by senaite.core, but by other add-ons.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
