### PR TITLE
Catalogs route

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.3 (unreleased)
 ------------------
 
+- #35 Added `catalogs` route
 - #34 Make senaite.jsonapi catalog-agnostic on searches
 
 1.2.2 (2020-03-03)

--- a/src/senaite/jsonapi/v1/routes/catalogs.py
+++ b/src/senaite/jsonapi/v1/routes/catalogs.py
@@ -42,9 +42,9 @@ def get(context, request, catalog_id=None):
 
         return {
             "id": catalog.id,
-            "indexes": catalog.indexes(),
-            "schema": catalog.schema(),
-            "portal_types": map(lambda it: it[1], portal_types),
+            "indexes": sorted(catalog.indexes()),
+            "schema": sorted(catalog.schema()),
+            "portal_types": sorted(map(lambda it: it[1], portal_types)),
         }
 
     if catalog_id:

--- a/src/senaite/jsonapi/v1/routes/catalogs.py
+++ b/src/senaite/jsonapi/v1/routes/catalogs.py
@@ -82,5 +82,5 @@ def get(context, request, catalog_id=None):
         "pages": batch.get_numpages(),
         "count": batch.get_sequence_length(),
         "items": records,
-        "url": api.url_for("senaite.jsonapi.v1.registry", key=catalog_id),
+        "url": api.url_for("senaite.jsonapi.v1.catalogs", key=catalog_id),
     }

--- a/src/senaite/jsonapi/v1/routes/catalogs.py
+++ b/src/senaite/jsonapi/v1/routes/catalogs.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.jsonapi import api
+from senaite.jsonapi import request as req
+from senaite.jsonapi.v1 import add_route
+
+
+@add_route("/catalogs", "senaite.jsonapi.v1.catalogs", methods=["GET"])
+@add_route("/catalogs/<string:key>", "senaite.jsonapi.v1.catalogs", methods=["GET"])
+def get(context, request, key=None):
+    """Returns all registered catalogs if key is None, otherwise try to fetch
+    the information about the catalog name passed in
+    """
+    # Get the catalogs
+    if key:
+        catalogs = [api.get_tool(key)]
+    else:
+        archetype_tool = api.get_tool("archetype_tool")
+        if not archetype_tool:
+            # Default catalog
+            catalogs = [api.get_tool("portal_catalog")],
+        else:
+            catalogs = archetype_tool.getCatalogsInSite()
+            catalogs = map(api.get_tool, catalogs)
+
+    def get_data(catalog):
+        return {
+            "id": catalog.id,
+            "indexes": catalog.indexes(),
+            "schema": catalog.schema(),
+            "portal_types": catalog.getPortalTypes(),
+        }
+
+    # Exclude some catalogs
+    skip = ["reference_catalog", "uid_catalog"]
+    catalogs = filter(lambda cat: cat.id not in skip, catalogs)
+
+    # Generate the metadata info for catalogs
+    records = map(get_data, catalogs)
+
+    # Prepare batch
+    size = req.get_batch_size()
+    start = req.get_batch_start()
+    batch = api.make_batch(records, size, start)
+
+    return {
+        "pagesize": batch.get_pagesize(),
+        "next": batch.make_next_url(),
+        "previous": batch.make_prev_url(),
+        "page": batch.get_pagenumber(),
+        "pages": batch.get_numpages(),
+        "count": batch.get_sequence_length(),
+        "items": records,
+        "url": api.url_for("senaite.jsonapi.v1.registry", key=key),
+    }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests adds the route `catalogs`:

http://localhost:8080/senaite/@@API/senaite/v1/catalogs/<catalog_id:optional>

If no catalog id is provided, this route returns a list with the catalogs registered in the system. If catalog id is provided, `senaite.jsonapi` returns the information for the catalog specified only.

For each catalog, the following information is displayed:

- id of the catalog
- indexes of the catalog
- metadata of the catalog (schema)
- portal types registered for this catalog


E.g.: http://localhost:8080/senaite/@@API/senaite/v1/catalogs/bika_catalog

```javascript

{
    _runtime: 0.0061838626861572266,
    id: "bika_catalog",
    schema: [
        "Created",
        "Description",
        "Title",
        "Type",
        "UID",
        "creator",
        "getClientBatchID",
        "getClientID",
        "getClientTitle",
        "getDateReceived",
        "getDateSampled",
        "getId",
        "getProgress",
        "id",
        "inactive_state",
        "path",
        "portal_type",
        "review_state",
        "sortable_title"
    ],
    portal_types: [
        "Batch",
        "ReferenceSample",
        "Sample",
        "SamplePartition"
    ],
    indexes: [
        "BatchDate",
        "Creator",
        "Description",
        "SearchableText",
        "Title",
        "Type",
        "UID",
        "allowedRolesAndUsers",
        "created",
        "description",
        "getAnalysesUIDs",
        "getBlank",
        "getClientBatchID",
        "getClientID",
        "getClientPatientID",
        "getClientTitle",
        "getClientUID",
        "getDateReceived",
        "getDateSampled",
        "getDueDate",
        "getExpiryDate",
        "getId",
        "getObjPositionInParent",
        "getReferenceDefinitionUID",
        "getSupportedServices",
        "id",
        "inactive_state",
        "isValid",
        "is_active",
        "listing_searchable_text",
        "path",
        "portal_type",
        "review_state",
        "sortable_title",
        "title",
        "worksheetanalysis_review_state"
    ]
}
```

## Current behavior before PR

Non-existing `catalogs` route

## Desired behavior after PR is merged

Existing `catalogs` route

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
