### PR TITLE
Semantics change in documentation get/view --> read

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,13 +61,13 @@ Operations
 ----------
 
 The API understands the basic `CRUD`_ operations on the *content resources*.
-Only the VIEW operation is accessible via a HTTP GET request. All other
+Only the READ operation is accessible via a HTTP GET request. All other
 operations have to be sent via a HTTP POST request.
 
 +-----------+---------------------------------------------+--------+
 | OPERATION | URL                                         | METHOD |
 +===========+=============================================+========+
-| VIEW      | <BASE URL>/<RESOURCE>/<uid:optional>        | GET    |
+| READ      | <BASE URL>/<RESOURCE>/<uid:optional>        | GET    |
 +-----------+---------------------------------------------+--------+
 | CREATE    | <BASE URL>/<RESOURCE>/create/<uid:optional> | POST   |
 +-----------+---------------------------------------------+--------+
@@ -91,7 +91,7 @@ DELETE too. When the UID is directly used, <RESOURCE> becomes optional:
 +-----------+---------------------------------------------+--------+
 | OPERATION | URL                                         | METHOD |
 +===========+=============================================+========+
-| VIEW      | <BASE URL>/<RESOURCE:optional>/<uid>        | GET    |
+| READ      | <BASE URL>/<RESOURCE:optional>/<uid>        | GET    |
 +-----------+---------------------------------------------+--------+
 | CREATE    | <BASE URL>/<RESOURCE:optional>/create/<uid> | POST   |
 +-----------+---------------------------------------------+--------+

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -4,7 +4,7 @@ Doctests
 .. include:: ../src/senaite/jsonapi/tests/doctests/auth.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/version.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/users.rst
-.. include:: ../src/senaite/jsonapi/tests/doctests/view.rst
+.. include:: ../src/senaite/jsonapi/tests/doctests/read.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/catalogs.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/search.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/create.rst

--- a/src/senaite/jsonapi/tests/doctests/read.rst
+++ b/src/senaite/jsonapi/tests/doctests/read.rst
@@ -1,9 +1,9 @@
-VIEW
+READ
 ----
 
 Running this test from the buildout directory:
 
-    bin/test test_doctests -t view
+    bin/test test_doctests -t read
 
 
 Test Setup


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Since we are referring to CRUD operations so frequently, better to refer to the Read operation instead of Get/View operation

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
