### PR TITLE
Revisit update route

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
+- #40 Prevent the id of objects of being accidentally updated
+- #40 Do not allow to update objects from setup folder
+- #40 Do not allow to update objects from portal root
+- #40 Fix upgrade does not work on post-only mode
+- #40 Adapter for custom handling of `update` operation
+- #37 Do not allow to create objects in setup folder
+- #37 Do not allow to create objects in portal root
 - #37 Adapter for custom handling of `create` operation
 - #37 Make the creation operation to be portal_type-naive
 - #35 Added `catalogs` route

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -21,11 +21,11 @@ There is a convenient and unified way to fetch the content without knowing the
 resource. This unified resource is directly located at the :ref:`BASE_URL`.
 
 
-GET
----
+READ
+----
 
-The `get` route is obsolete. Please use the base url to retrieve a content by
-uid, as explained in :ref:`Operations`. E.g.:
+Use the base url to retrieve a content by uid, as explained in :ref:`Operations`.
+E.g.:
 
 http://localhost:8080/senaite/@@API/senaite/v1/<uid>
 

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -2,7 +2,7 @@ CRUD
 ====
 
 Each content route provider shipped with this package, provides the basic CRUD
-:ref:`Operations` functionality to `get`, `create`, `delete` and `update` the
+:ref:`Operations` functionality to `create`, `read`, `update` and `delete` the
 resource handled, except that the `delete` operation tries to deactivate the
 resource instead of deleting it. The reason is that for traceability reasons,
 *delete* operation is not supported in SENAITE LIMS.
@@ -19,15 +19,6 @@ Unified API
 
 There is a convenient and unified way to fetch the content without knowing the
 resource. This unified resource is directly located at the :ref:`BASE_URL`.
-
-
-READ
-----
-
-Use the base url to retrieve a content by uid, as explained in :ref:`Operations`.
-E.g.:
-
-http://localhost:8080/senaite/@@API/senaite/v1/<uid>
 
 
 CREATE
@@ -152,6 +143,18 @@ where:
           explained in :ref:`Operations`.
           Remember that in SENAITE LIMS, the portal type that represents samples
           is `AnalysisRequest`.
+
+
+READ
+----
+
+The `read` route does not exist, use the base url to retrieve a content by uid,
+as explained in :ref:`Operations`. E.g.:
+
+http://localhost:8080/senaite/@@API/senaite/v1/<uid>
+
+Please, refer to :ref:`Search_Resource` section to learn how to search objects.
+
 
 UPDATE
 ------

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -79,7 +79,7 @@ Body Content type (application/json):
 
     {
         "portal_type": "Client",
-        "Name": "Test Client",
+        "title": "Test Client",
         "ClientID": "TEST-01",
         "parent_path": "/senaite/clients"
     }
@@ -107,7 +107,7 @@ Body Content type (application/json):
           "hours": 0,
           "minutes": 0
         },
-        "parent_path": "/bika_setup/bika_sampletypes"
+        "parent_path": "/senaite/bika_setup/bika_sampletypes"
     }
 
 

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -180,6 +180,8 @@ from the parent container as well.
 
    In such cases, `senaite.jsonapi` will always return a 401 response.
 
+The `update` route can also be used to perform transitions by using the keyword
+`transition` in the HTTP POST body.
 
 The examples below show possible variations of a HTTP POST body sent to the
 JSON API with the header **Content-Type: application/json** set. Remember you
@@ -191,7 +193,7 @@ Example
 
 Given this Request URL:
 
-http://localhost:8080/senaite/@@API/senaite/v1/update/
+http://localhost:8080/senaite/@@API/senaite/v1/update
 
 the following POSTs are equivalent, all them update the "Priority" of sample
 DBS-00012 to 2:
@@ -217,6 +219,21 @@ DBS-00012 to 2:
         "parent_path": "/senaite/clients/client-1",
         "Priority": 2,
     }
+
+Using the same URL with this HTTP POST body:
+
+.. code-block:: javascript
+
+    {
+        "uid": <uid_of_sample_DBS-00012>,
+        "Priority": 2,
+        "transition": "receive"
+    }
+
+will update the "Priority" field of the sample to `2` and will perform the
+transition "receive" to the Sample with id `DBS-00012`. This transition will
+only take place if the sample is in a suitable status and the user has enough
+privileges for the transition to take place.
 
 DELETE
 ------

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -156,8 +156,8 @@ specify all the information in the HTTP POST body by using either:
 - `path` parameter, as the physical path to the object, or
 - `uid` parameter, as the UID of the object
 
-Alternatively, you can use `id` and `path` parameters with the values from the
-parent container as well.
+Alternatively, you can use `id` and `parent_path` parameters with the values
+from the parent container as well.
 
 Example
 .......
@@ -166,7 +166,8 @@ Given this Request URL:
 
 http://localhost:8080/senaite/@@API/senaite/v1/update/
 
-the following POSTs are equivalent, all them update the "Priority" of sample DBS-00012 to 2:
+the following POSTs are equivalent, all them update the "Priority" of sample
+DBS-00012 to 2:
 
 .. code-block:: javascript
 
@@ -186,7 +187,7 @@ the following POSTs are equivalent, all them update the "Priority" of sample DBS
 
     {
         "id": "DBS-00012",
-        "path": "/senaite/clients/client-1/",
+        "parent_path": "/senaite/clients/client-1",
         "Priority": 2,
     }
 

--- a/docs/crud.rst
+++ b/docs/crud.rst
@@ -60,6 +60,16 @@ Additional fields might be required depending on the resource to be created. For
 instance, for the creation of a `Client` object, values for two additional
 fields are required: `Name` and `ClientID`.
 
+.. important::
+   SENAITE.JSONAPI does not allow the creation of objects when:
+
+   - the container is the portal root (`senaite` path)
+   - the container is senaite's setup (`senaite/bika_setup` path)
+   - the container does not allow the specified `portal_type`
+
+   In such cases, `senaite.jsonapi` will always return a 401 response.
+
+
 The examples below show possible variations of a HTTP POST body sent to the
 JSON API with the header **Content-Type: application/json** set. Remember you
 can use the `Advanced Rest Client`_ Application to send POST requests. See
@@ -158,6 +168,20 @@ specify all the information in the HTTP POST body by using either:
 
 Alternatively, you can use `id` and `parent_path` parameters with the values
 from the parent container as well.
+
+.. important::
+   SENAITE.JSONAPI does not allow the update of objects when:
+
+   - the container is the portal root (`senaite` path)
+   - the container is senaite's setup (`senaite/bika_setup` path)
+
+   In such cases, `senaite.jsonapi` will always return a 401 response.
+
+
+The examples below show possible variations of a HTTP POST body sent to the
+JSON API with the header **Content-Type: application/json** set. Remember you
+can use the `Advanced Rest Client`_ Application to send POST requests. See
+:doc:`installation` for details.
 
 Example
 .......

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -4,8 +4,8 @@ Doctests
 .. include:: ../src/senaite/jsonapi/tests/doctests/auth.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/version.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/users.rst
-.. include:: ../src/senaite/jsonapi/tests/doctests/read.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/catalogs.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/search.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/create.rst
+.. include:: ../src/senaite/jsonapi/tests/doctests/read.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/update.rst

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -8,3 +8,4 @@ Doctests
 .. include:: ../src/senaite/jsonapi/tests/doctests/catalogs.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/search.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/create.rst
+.. include:: ../src/senaite/jsonapi/tests/doctests/update.rst

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -742,7 +742,7 @@ Register the adapter in your `configure.zcml` file for your special interface:
     <configure
         xmlns="http://namespaces.zope.org/zope">
 
-        <!-- Adapter for a creation custom adapter -->
+        <!-- Adapter for custom update -->
         <adapter
           factory=".TodoUpdateAdapter"
           provides="senaite.jsonapi.interfaces.IUpdate"

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -699,11 +699,6 @@ own. This interface provides the folllowing signatures:
             """Returns whether the update of the object is allowed
             """
 
-        def is_update_delegated(self):
-            """Returns whether the update of this object has to be delegated to
-            this adapter
-            """
-
         def update_object(self, **data):
             """Updates the object
             """
@@ -785,21 +780,14 @@ same time. You can use the same adapter as before:
             """
             return True
 
-        def is_update_delegated(self):
-            """Returns whether the update of this object has to be delegated to
-            this adapter
-            """
-            return True
-
         def update_object(self, **data):
             """Updates the object
             """
-            self.context.setRemarks("Updated throuh json.api")
+            self.context.setRemarks("Updated through json.api")
             self.context.edit(**data)
             self.context.reindexObject()
 
 
 With this example, `senaite.jsonapi` will not follow the default procedure of
 update, but delegate the operation to the function `update_object` of this
-adapter. Note the update will only be delegated when the function
-`is_update_delegated` returns True.
+adapter.

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -655,7 +655,7 @@ the same adapter as before:
             """
             return True
 
-        def create_object(self):
+        def create_object(self, **data):
             """Creates an object
             """
             obj = _createObjectByType("Todo", self.container, tmpID())
@@ -665,6 +665,141 @@ the same adapter as before:
             return obj
 
 With this example, `senaite.jsonapi` will not follow the default procedure of
-creation, it will rather delegate the operation of the `Todo` object to the
-function `create_object` of this adapter. Note the creation will only be
-delegated when the function `is_creation_delegated` returns True.
+creation, but delegate the operation to the function `create_object` of this
+adapter. Note the creation will only be delegated when the function
+`is_creation_delegated` returns True.
+
+
+.. _ADAPTER_UPDATE:
+
+Adding an adapter for update operation
+--------------------------------------
+
+Sometimes, one might want to handle the update of a given object differently,
+either because:
+
+- you want an object to never be updated through `senaite.jsonapi`
+- you want an object to only be updated in some specific circumstances
+- you want to add some additional logic within the update process
+- etc.
+
+:ref:`DATA_MANAGER` or :ref:`FIELD_MANAGER` allows to achieve these goals
+partially, cause their scope is at field level. If you need full control over
+the update process, you can also create an adapter implementing `IUpdate`
+interface. This interface allows you to handle the `update` operation by your
+own. This interface provides the folllowing signatures:
+
+.. code-block:: python
+
+    class IUpdate(interface.Interface):
+        """Interface to handle update of objects
+        """
+
+        def is_update_allowed(self):
+            """Returns whether the update of the object is allowed
+            """
+
+        def is_update_delegated(self):
+            """Returns whether the update of this object has to be delegated to
+            this adapter
+            """
+
+        def update_object(self, **data):
+            """Updates the object
+            """
+
+
+Allow/disallow to update an object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For instance, say you don't want to allow the update of objects from type
+`Todo` through the `senaite.jsonapi`:
+
+.. code-block:: python
+
+    from senaite.jsonapi.interfaces import IUpdate
+    from zope import interface
+
+
+    class TodoUpdateAdapter(object):
+        """Custom adapter for the update of objects from Todo type
+        """
+        interface.implements(IUpdate)
+
+        def __init__(self, context):
+            self.context = context
+
+        def is_update_allowed(self):
+            """Returns whether the update of the object is allowed
+            """
+            return False
+
+
+Register the adapter in your `configure.zcml` file for your special interface:
+
+.. code-block:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope">
+
+        <!-- Adapter for a creation custom adapter -->
+        <adapter
+          factory=".TodoUpdateAdapter"
+          provides="senaite.jsonapi.interfaces.IUpdate"
+          for="my.addon.interfaces.ITodo" />
+
+    </configure>
+
+
+.. note::
+    This adapter is initialized with `context`, the object to be updated.
+
+.. note::
+    We've used here a custom `Todo` type, but you can use this approach for any
+    type registered in the system, being it from `senaite.core` (e.g. `Client',
+    `SampleType`, etc.) or from any other add-on.
+
+
+Custom update of an object
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Imagine that besides updating your object, you want to add a `Remarks` at the
+same time. You can use the same adapter as before:
+
+.. code-block:: python
+
+    from senaite.jsonapi.interfaces import IUpdate
+    from zope import interface
+
+
+    class TodoUpdateAdapter(object):
+        """Custom adapter for the update of objects from Todo type
+        """
+        interface.implements(IUpdate)
+
+        def __init__(self, context):
+            self.context = context
+
+        def is_update_allowed(self):
+            """Returns whether the update of the object is allowed
+            """
+            return True
+
+        def is_update_delegated(self):
+            """Returns whether the update of this object has to be delegated to
+            this adapter
+            """
+            return True
+
+        def update_object(self, **data):
+            """Updates the object
+            """
+            self.context.setRemarks("Updated throuh json.api")
+            self.context.edit(**data)
+            self.context.reindexObject()
+
+
+With this example, `senaite.jsonapi` will not follow the default procedure of
+update, but delegate the operation to the function `update_object` of this
+adapter. Note the update will only be delegated when the function
+`is_creation_delegated` returns True.

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -802,4 +802,4 @@ same time. You can use the same adapter as before:
 With this example, `senaite.jsonapi` will not follow the default procedure of
 update, but delegate the operation to the function `update_object` of this
 adapter. Note the update will only be delegated when the function
-`is_creation_delegated` returns True.
+`is_update_delegated` returns True.

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1455,7 +1455,7 @@ def update_object_with_data(content, record):
 
     # Look for an update-specific adapter for this object
     adapter = queryAdapter(content, IUpdate)
-    if adapter and adapter.is_update_delegated():
+    if adapter:
         # Use the adapter to update the object
         logger.info("Delegating 'update' operation of '{}'".format(
             api.get_path(content)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1469,8 +1469,7 @@ def update_object_with_data(content, record):
 
         # Bail-out non-update-able fields
         purged_records = copy.deepcopy(record)
-        for field_id in filter(lambda it: it in record, SKIP_UPDATE_FIELDS):
-            del(purged_records[field_id])
+        map(lambda key: purged_records.pop(key, None), SKIP_UPDATE_FIELDS)
 
         # Iterate through record items
         for k, v in purged_records.items():

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1107,6 +1107,10 @@ def is_update_allowed(obj):
     :returns: True if it is allowed to update this object
     :rtype: bool
     """
+    # Do not allow to update the site itself
+    if api.is_portal(obj):
+        return False
+
     # Do not allow the update of objects that belong to site root folder
     parent = api.get_parent(obj)
     if api.is_portal(parent):
@@ -1121,8 +1125,7 @@ def is_update_allowed(obj):
     if adapter:
         return adapter.is_update_allowed()
 
-    # We do not support the update of inactive objects
-    return api.is_active(obj)
+    return True
 
 
 def url_for(endpoint, default=DEFAULT_ENDPOINT, **values):

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -152,3 +152,21 @@ class ICreate(interface.Interface):
     def create_object(self, **data):
         """Creates an object
         """
+
+
+class IUpdate(interface.Interface):
+    """Interface to handle update of objects
+    """
+
+    def is_update_allowed(self):
+        """Returns whether the update of the object is allowed
+        """
+
+    def is_update_delegated(self):
+        """Returns whether the update of this object has to be delegated to
+        this adapter
+        """
+
+    def update_object(self, **data):
+        """Updates the object
+        """

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -162,11 +162,6 @@ class IUpdate(interface.Interface):
         """Returns whether the update of the object is allowed
         """
 
-    def is_update_delegated(self):
-        """Returns whether the update of this object has to be delegated to
-        this adapter
-        """
-
     def update_object(self, **data):
         """Updates the object
         """

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -216,7 +216,7 @@ def get_request_data():
     request = get_request()
     data = request.get("BODY", "{}")
     if not is_json_deserializable(data):
-        from plone.jsonapi.routes.exceptions import APIError
+        from senaite.jsonapi.exceptions import APIError
         raise APIError(400, "Request Data is not JSON deserializable – Check JSON Syntax!")
     out_data = json.loads(data)
 

--- a/src/senaite/jsonapi/tests/doctests/update.rst
+++ b/src/senaite/jsonapi/tests/doctests/update.rst
@@ -1,4 +1,4 @@
-CREATE
+UPDATE
 ------
 
 Running this test from the buildout directory:
@@ -39,11 +39,6 @@ Functional Helpers:
     ...     item = response.get("items")[0]
     ...     assert("uid" in item)
     ...     return api.get_object(item["uid"])
-
-    >>> def read(uid):
-    ...     response = get(uid)
-    ...     return get_item_object(response)
-
 
     >>> def create(data):
     ...     response = post("create", data)

--- a/src/senaite/jsonapi/tests/doctests/update.rst
+++ b/src/senaite/jsonapi/tests/doctests/update.rst
@@ -44,9 +44,6 @@ Functional Helpers:
     ...     response = get(uid)
     ...     return get_item_object(response)
 
-    >>> def update(data):
-    ...     response = post("update", data)
-    ...     return get_item_object(response)
 
     >>> def create(data):
     ...     response = post("create", data)
@@ -141,3 +138,36 @@ path of the container object:
     >>> obj = get_item_object(response)
     >>> obj.getClientID()
     'CC5'
+
+
+Update restrictions
+~~~~~~~~~~~~~~~~~~~
+
+We get a 401 error if we try to update an object from inside portal root:
+
+    >>> data = {"title": "My clients folder",
+    ...         "uid": api.get_uid(clients),}
+    >>> post("update", data)
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 401: Unauthorized
+
+We get a 401 error if we try to update an object from inside setup folder:
+
+    >>> cats_uid = api.get_uid(api.get_setup().bika_analysiscategories)
+    >>> data = {"title": "My Analysis Categories folder",
+    ...         "uid": cats_uid,}
+    >>> post("update", data)
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 401: Unauthorized
+
+We cannot update the `id` of an object:
+
+    >>> original_id = api.get_id(client1)
+    >>> data = {"id": "client-123123",
+    ...         "uid": client_uid }
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> api.get_id(obj) == original_id
+    True

--- a/src/senaite/jsonapi/tests/doctests/update.rst
+++ b/src/senaite/jsonapi/tests/doctests/update.rst
@@ -134,6 +134,32 @@ path of the container object:
     >>> obj.getClientID()
     'CC5'
 
+Do a transition
+~~~~~~~~~~~~~~~
+
+We can transition the objects by using the keyord `transition` in the data sent
+via POST:
+
+    >>> api.is_active(client1)
+    True
+    >>> data = {"uid": api.get_uid(client1),
+    ...         "transition": "deactivate"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> api.is_active(obj)
+    False
+
+We can update and transition at same time:
+
+    >>> data = {"uid": api.get_uid(client1),
+    ...         "ClientID": "CC6",
+    ...         "transition": "activate"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> api.is_active(obj)
+    True
+    >>> obj.getClientID()
+    'CC6'
 
 Update restrictions
 ~~~~~~~~~~~~~~~~~~~

--- a/src/senaite/jsonapi/tests/doctests/update.rst
+++ b/src/senaite/jsonapi/tests/doctests/update.rst
@@ -1,0 +1,143 @@
+CREATE
+------
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t update
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> import urllib
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+    >>> from bika.lims import api
+
+Functional Helpers:
+
+    >>> def get(url):
+    ...     browser.open("{}/{}".format(api_url, url))
+    ...     return browser.contents
+
+    >>> def post(url, data):
+    ...     url = "{}/{}".format(api_url, url)
+    ...     browser.post(url, urllib.urlencode(data, doseq=True))
+    ...     return browser.contents
+
+    >>> def get_item_object(response):
+    ...     assert("items" in response)
+    ...     response = json.loads(response)
+    ...     items = response.get("items")
+    ...     assert(len(items)==1)
+    ...     item = response.get("items")[0]
+    ...     assert("uid" in item)
+    ...     return api.get_object(item["uid"])
+
+    >>> def read(uid):
+    ...     response = get(uid)
+    ...     return get_item_object(response)
+
+    >>> def update(data):
+    ...     response = post("update", data)
+    ...     return get_item_object(response)
+
+    >>> def create(data):
+    ...     response = post("create", data)
+    ...     return get_item_object(response)
+
+Variables:
+
+    >>> portal = self.portal
+    >>> portal_url = portal.absolute_url()
+    >>> api_url = "{}/@@API/senaite/v1".format(portal_url)
+    >>> setup = api.get_setup()
+    >>> browser = self.getBrowser()
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+Initialize the instance with some objects for testing:
+
+    >>> clients = api.get_portal().clients
+    >>> data = {"portal_type": "Client",
+    ...         "parent_path": api.get_path(clients),
+    ...         "title": "Chicken corp",
+    ...         "ClientID": "CC"}
+    >>> client1 = create(data)
+
+    >>> data = {"portal_type": "Client",
+    ...         "parent_path": api.get_path(clients),
+    ...         "title": "Beef Corp",
+    ...         "ClientID": "BC"}
+    >>> client2 = create(data)
+
+    >>> data = {"portal_type": "Client",
+    ...         "parent_path": api.get_path(clients),
+    ...         "title": "Octopus Corp",
+    ...         "ClientID": "OC"}
+    >>> client3 = create(data)
+
+
+Update by resource and uid
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We can update an object by providing the resource and the uid of the object:
+
+    >>> client_uid = api.get_uid(client1)
+    >>> data = {"ClientID": "CC1"}
+    >>> response = post("client/update/{}".format(client_uid), data)
+    >>> obj = get_item_object(response)
+    >>> obj.getClientID()
+    'CC1'
+
+Update by uid without resource
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Even easier, we can update with only the uid:
+
+    >>> data = {"ClientID": "CC2"}
+    >>> response = post("update/{}".format(client_uid), data)
+    >>> obj = get_item_object(response)
+    >>> obj.getClientID()
+    'CC2'
+
+Update via post only
+~~~~~~~~~~~~~~~~~~~~
+
+When updating by resource (without an UID explicitly set), the system expects a
+the data to passed via POST to contain the item to be updated.
+
+The object to be updated can be send in the HTTP POST body by using the `uid`:
+
+    >>> data = {"uid": client_uid,
+    ...         "ClientID": "CC3"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> obj.getClientID()
+    'CC3'
+
+By using the `path`, as the physical path of the object:
+
+    >>> data = {"path": api.get_path(client1),
+    ...         "ClientID": "CC4"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> obj.getClientID()
+    'CC4'
+
+Or by using the `id` of the object together with `parent_path`, as the physical
+path of the container object:
+
+    >>> data = {"id": api.get_id(client1),
+    ...         "parent_path": api.get_path(clients),
+    ...         "ClientID": "CC5"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> obj.getClientID()
+    'CC5'

--- a/src/senaite/jsonapi/v1/routes/content.py
+++ b/src/senaite/jsonapi/v1/routes/content.py
@@ -72,6 +72,12 @@ def get(context, request, resource=None, uid=None):
 def action(context, request, action=None, resource=None, uid=None):
     """Various HTTP POST actions
     """
+    # Allow to set the method via the header
+    # This is used to support Backbone.js REST API
+    if action is None:
+        action = request.get_header("HTTP_X_HTTP_METHOD_OVERRIDE", None)
+        action = action and action.lower() or None
+
     # Fetch and call the action function of the API
     func_name = "{}_items".format(action)
     action_func = getattr(api, func_name, None)

--- a/src/senaite/jsonapi/v1/routes/content.py
+++ b/src/senaite/jsonapi/v1/routes/content.py
@@ -30,7 +30,7 @@ ACTIONS = "create,update,delete"
            "senaite.jsonapi.v1.get", methods=["GET"])
 #
 # /<resource (portal_type)>/<uid>
-@add_route("/<string:resource>/<string(maxlength=32):uid>",
+@add_route("/<string:resource>/<string(length=32):uid>",
            "senaite.jsonapi.v1.get", methods=["GET"])
 @add_route("/<string:resource>/<string(length=32):uid>",
            "senaite.jsonapi.v1.get", methods=["GET"])
@@ -59,26 +59,19 @@ def get(context, request, resource=None, uid=None):
 # http://werkzeug.pocoo.org/docs/0.11/routing/#custom-converters
 @add_route("/<any(" + ACTIONS + "):action>",
            "senaite.jsonapi.v1.action", methods=["POST"])
-@add_route("/<string:resource>",
+@add_route("/<string:resource>/<string(length=32):uid>",
            "senaite.jsonapi.v1.action", methods=["POST"])
-@add_route("/<string:resource>/<string(maxlength=32):uid>",
-           "senaite.jsonapi.v1.action", methods=["POST"])
-@add_route("/<any(" + ACTIONS + "):action>/<string(maxlength=32):uid>",
+@add_route("/<any(" + ACTIONS + "):action>/<string(length=32):uid>",
            "senaite.jsonapi.v1.action", methods=["POST"])
 @add_route("/<string(length=32):uid>",
            "senaite.jsonapi.v1.action", methods=["POST"])
 @add_route("/<string:resource>/<any(" + ACTIONS + "):action>",
            "senaite.jsonapi.v1.action", methods=["POST"])
-@add_route("/<string:resource>/<any(" + ACTIONS + "):action>/<string(maxlength=32):uid>",
+@add_route("/<string:resource>/<any(" + ACTIONS + "):action>/<string(length=32):uid>",
            "senaite.jsonapi.v1.action", methods=["POST"])
 def action(context, request, action=None, resource=None, uid=None):
     """Various HTTP POST actions
     """
-
-    # allow to set the method via the header
-    if action is None:
-        action = request.get_header("HTTP_X_HTTP_METHOD_OVERRIDE", "CREATE").lower()
-
     # Fetch and call the action function of the API
     func_name = "{}_items".format(action)
     action_func = getattr(api, func_name, None)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reviews the behavior of update route and adds doctests as well.

The following has been fixed:

- Objects were not updated when only the route `update` was used (without neither `resource` nor `uid`. The reason is that the route `/<string:resource>` was masking the route `/<any(" + ACTIONS + "):action>`. https://github.com/senaite/senaite.jsonapi/commit/0e5377c02eb2b17f7beca1bc818d228060853bbb

The following has been added:

- `IUpdate` for custom update adapters

And the following restrictions have been added:

- A 401 Unauthorized error is rised when trying to update an object from inside portal root.
- A 401 Unauthorized error is rised when trying to update an object from inside setup folder
- Do never update field `id`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
