### PR TITLE
Added push endpoint for custom jobs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.2.4 (unreleased)
+------------------
+
+- #41 Push endpoint for custom jobs
+
+
 1.2.3 (2020-08-05)
 ------------------
 

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -9,3 +9,4 @@ Doctests
 .. include:: ../src/senaite/jsonapi/tests/doctests/create.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/read.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/update.rst
+.. include:: ../src/senaite/jsonapi/tests/doctests/push.rst

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -834,16 +834,21 @@ Add the following adapter in your add-on:
             emails = self.get_emails()
 
             # Send the emails
-            for email in emails:
-                self.compose_and_send(email, message)
+            success = map(lambda e: self.send(e, subject, message), emails)
+            return any(success)
 
         def get_emails(self):
+            """Returns the emails from all registered contacts
+            """
             query = {"portal_type": ["Contact", "LabContact"]}
             contacts = map(api.get_object, api.search(query, "portal_catalog"))
             emails = map(lambda c: c.getEmailAddress(), contacts)
-            return filter(None, emails)
+            emails = filter(None, emails)
+            return list(OrderedDict.fromkeys(uids))
 
-        def compose_and_send(self, email, subject, body):
+        def send(self, email, subject, body):
+            """Creates and sends an email message
+            """
             lab = api.get_setup().laboratory
             from_addr = lab.getEmailAddress()
             msg = mailapi.compose(from_addr, email, subject, body)

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -882,6 +882,7 @@ Body Content type (application/json):
 
     {
         "consumer": "my.addon.push.emailnotifier",
+        "subject": "Sheduled LIMS maintenance",
         "message": "System will not be available from 16:00 to 18:00",
     }
 

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -165,3 +165,16 @@ class IUpdate(interface.Interface):
     def update_object(self, **data):
         """Updates the object
         """
+
+
+class IPushConsumer(interface.Interface):
+    """Interface to handle hetergeneous jobs
+    """
+
+    def __init__(self, record):
+        """Record containing the job required information
+        """
+
+    def process(self):
+        """Processes the job or raises an Exception if unable to succeed
+        """

--- a/src/senaite/jsonapi/tests/doctests/push.rst
+++ b/src/senaite/jsonapi/tests/doctests/push.rst
@@ -1,0 +1,77 @@
+PUSH
+----
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t push
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> import urllib
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from senaite.jsonapi.interfaces import IPushConsumer
+    >>> from zope.component import getGlobalSiteManager
+    >>> from zope.interface import implements
+
+Functional Helpers:
+
+    >>> def post(url, data):
+    ...     url = "{}/{}".format(api_url, url)
+    ...     browser.post(url, urllib.urlencode(data, doseq=True))
+    ...     return browser.contents
+
+Variables:
+
+    >>> portal = self.portal
+    >>> portal_url = portal.absolute_url()
+    >>> api_url = "{}/@@API/senaite/v1".format(portal_url)
+    >>> browser = self.getBrowser()
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+Create a dummy `IPushConsumer` adapter:
+
+    >>> class DummyConsumerAdapter(object):
+    ...     implements(IPushConsumer)
+    ...
+    ...     def __init__(self, record):
+    ...         self.record = record
+    ...
+    ...     def process(self):
+    ...         if not self.record.get("target"):
+    ...             return False
+    ...         return True
+
+    >>> sm = getGlobalSiteManager()
+    >>> sm.registerAdapter(DummyConsumerAdapter, (dict,), IPushConsumer, name="dummy")
+    >>> transaction.commit()
+
+
+Push with success
+~~~~~~~~~~~~~~~~~
+
+    >>> post("push", {"consumer": "dummy", "target": "defined"})
+    '..."success": true...'
+
+Push without success
+~~~~~~~~~~~~~~~~~~~~
+
+If an adapter is registered, but it rises an exception, the outcome is failed:
+
+    >>> post("push", {"consumer": "dummy"})
+    '..."success": false...'
+
+Non-registered adapter
+~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> post("push", {"consumer": "zummy"})
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 500: Internal Server Error

--- a/src/senaite/jsonapi/v1/routes/push.py
+++ b/src/senaite/jsonapi/v1/routes/push.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.jsonapi import api
+from senaite.jsonapi import request as req
+from senaite.jsonapi.interfaces import IPushConsumer
+from senaite.jsonapi.v1 import add_route
+from zope.component import queryAdapter
+
+
+@add_route("/push", "senaite.jsonapi.v1.push", methods=["POST"])
+def push(context, request):
+
+    # disable CSRF
+    req.disable_csrf_protection()
+
+    # Cannot push being an anonymous user!
+    if api.is_anonymous():
+        api.fail(401, "Anonymous user")
+
+    # extract the data from the request
+    records = req.get_request_data()
+    if not records:
+        api.fail(500, "No data sent")
+
+    if len(records) > 1:
+        api.fail(500, "Push with multiple entries is not supported")
+
+    # Get the record containing the data for this push
+    record = records[0]
+
+    # Name of the adapter that will be able to handle this POST data
+    name = record.get("consumer")
+    if not name:
+        api.fail(500, "No consumer name provided")
+
+    consumer = queryAdapter(record, IPushConsumer, name=name)
+    if consumer is None:
+        api.fail(500, "No consumer registered for name={}".format(name))
+
+    try:
+        success = consumer.process()
+    except Exception as e:
+        api.fail(500, e.message)
+
+    return {
+        "url": api.url_for("senaite.jsonapi.v1.push"),
+        "success": success,
+    }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Sometimes is useful to have and endpoint to allow the execution of custom logic without bothering about creating views, handing JSON, etc. This PR adds a "push" end-point that acts as a gateway for custom processes or actions.

## Current behavior before PR

No push endpoint for custom jobs

## Desired behavior after PR is merged

Push endpoint for custom jobs

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
