### PR TITLE
Fix malformed API call

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-
+- #43 Fix malformed API call
 
 
 2.0.0 (2021-07-27)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -625,7 +625,7 @@ def get_portal():
 def get_tool(name, default=_marker):
     """Proxy to senaite.api.get_tool
     """
-    return api.get_tool(name, default)
+    return api.get_tool(name, default=default)
 
 
 def get_object(brain_or_object):


### PR DESCRIPTION


## Description of the issue/feature this PR addresses

This PR fixes the logging of this warning:

2021-10-29 15:54:42 WARNING senaite.core get_tool::getToolByName(<object object at 0x11e772420>, 'portal_types') failed: APIError('<object object at 0x11e772420> is not supported.',) -> falling back to plone.api.portal.get_tool('portal_types')

## Current behavior before PR

A lot of warning logs appeared

## Desired behavior after PR is merged

No more warning logs appear

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
