### PR TITLE
fix update api routine

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -199,7 +199,7 @@ def update_items(portal_type=None, uid=None, endpoint=None, **kw):
         if not is_update_allowed(obj):
             fail(401, "Update of {} is not allowed".format(api.get_path(obj)))
 
-        obj = update_object_with_data(obj, record)
+        obj = update_object_with_data(obj, **record)
         return make_items_for([obj], endpoint=endpoint)
 
     # no uid -> go through the record items
@@ -216,7 +216,7 @@ def update_items(portal_type=None, uid=None, endpoint=None, **kw):
             fail(401, "Update of {} is not allowed".format(api.get_path(obj)))
 
         # update the object with the given record data
-        obj = update_object_with_data(obj, record)
+        obj = update_object_with_data(obj, **record)
         results.append(obj)
 
     if not results:


### PR DESCRIPTION
small fix

## Description of the issue/feature this PR addresses
small fix

## Current behavior before PR
Calling UPDATE operation raises python error: mismatch arguments signature:

```
[_runtime:0.005409955978393555, message:update_object_with_data() takes exactly 1 argument (2 given), success:false]
```

## Desired behavior after PR is merged
update object

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
