### PR TITLE
Fix ZCTextIndex lookup for custom searchable text query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #46 Fix ZCTextIndex lookup for custom searchable text query
 
 
 2.1.0 (2022-01-05)

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -19,11 +19,14 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+import re
 import urlparse
+
 import pkg_resources
 
+from senaite.jsonapi import logger
+from senaite.jsonapi import underscore as _
 from zope import interface
-
 from zope.globalrequest import getRequest
 
 try:
@@ -33,9 +36,6 @@ except (pkg_resources.DistributionNotFound, ImportError):
     HAS_PLONE_PROTECT = False
 else:
     HAS_PLONE_PROTECT = True
-
-from senaite.jsonapi import logger
-from senaite.jsonapi import underscore as _
 
 
 # These values evaluate to True
@@ -177,11 +177,10 @@ def get_query():
     """ returns the 'query' from the request
     """
     q = get("q", "")
-
-    qs = q.lstrip("*.!$%&/()=#-+:'`´^")
-    if qs and not qs.endswith("*"):
-        qs += "*"
-    return qs
+    tokens = re.split(r"[^a-zA-Z0-9]", q, flags=re.IGNORECASE)
+    tokens = filter(None, tokens)
+    tokens = map(lambda t: t + "*", tokens)
+    return " AND ".join(tokens)
 
 
 def get_path():

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -24,6 +24,7 @@ import urlparse
 
 import pkg_resources
 
+from bika.lims import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import underscore as _
 from zope import interface
@@ -177,7 +178,8 @@ def get_query():
     """ returns the 'query' from the request
     """
     q = get("q", "")
-    tokens = re.split(r"[^a-zA-Z0-9]", q, flags=re.IGNORECASE)
+    term = api.safe_unicode(q)
+    tokens = re.split(r"[^\w]", term, flags=re.U | re.I)
     tokens = filter(None, tokens)
     tokens = map(lambda t: t + "*", tokens)
     return " AND ".join(tokens)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the index lookup for custom queries with a `q` parameter

## Current behavior before PR

It was always the index `SearchableText` used, no matter if it existed or not

## Desired behavior after PR is merged

A suitable `ZCTextIndex` is looked up from the catalog and used for the query

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
