### PR TITLE
Use searchable text index converter from catalog API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #47 Use searchable text index converter from catalog API
 - #46 Fix ZCTextIndex lookup for custom searchable text query
 
 

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -19,12 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
-import re
 import urlparse
 
 import pkg_resources
 
-from bika.lims import api
+from senaite.core.api.catalog import to_searchable_text_qs
 from senaite.jsonapi import logger
 from senaite.jsonapi import underscore as _
 from zope import interface
@@ -177,12 +176,8 @@ def get_sort_order():
 def get_query():
     """ returns the 'query' from the request
     """
-    q = get("q", "")
-    term = api.safe_unicode(q)
-    tokens = re.split(r"[^\w]", term, flags=re.U | re.I)
-    tokens = filter(None, tokens)
-    tokens = map(lambda t: t + "*", tokens)
-    return " AND ".join(tokens)
+    qs = get("q", "")
+    return to_searchable_text_qs(qs)
 
 
 def get_path():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR uses the searchable text converter from senaite.core.api.catalog to build a proper query string in listings

Relevant PRs:

- https://github.com/senaite/senaite.core/pull/1908
- https://github.com/senaite/senaite.core/pull/1910

## Current behavior before PR

Querystring was parsed separately in the request module

## Desired behavior after PR is merged

Querystring converter from `senaite.core.api.catalog` is used

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
