### PR TITLE
Fix no error message is sent back for push consumer calls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #49 Fix no error message is sent back for push consumer calls
 - no changes yet
 
 

--- a/src/senaite/jsonapi/v1/routes/push.py
+++ b/src/senaite/jsonapi/v1/routes/push.py
@@ -58,7 +58,7 @@ def push(context, request):
     try:
         success = consumer.process()
     except Exception as e:
-        api.fail(500, e.message)
+        api.fail(500, str(e))
 
     return {
         "url": api.url_for("senaite.jsonapi.v1.push"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that when push consumer fails, an error message is always sent back in accordance, regardless of the Exception type.

## Current behavior before PR

```JSON
{
"_runtime": 85.57789301872253,
"message": "",
"success": false
}
```

## Desired behavior after PR is merged

```JSON
{
"_runtime": 0.0049631595611572266,
"message": "[Errno 13] Permission denied: '/home/senaite'",
"success": false
}
```
--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
