### PR TITLE
Handle no access to parent object gracefully

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- no changes yet
+- #51 Handle no access to parent object gracefully
 
 
 2.3.0 (2022-10-03)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -395,7 +395,14 @@ def get_parent_info(brain_or_object, endpoint=None):
         return {}
 
     # get the parent object
-    parent = get_parent(brain_or_object)
+    try:
+        parent = get_parent(brain_or_object)
+    except Unauthorized:
+        return {
+            "parent_id": "",
+            "parent_uid": "",
+            "parent_url": "",
+        }
     portal_type = get_portal_type(parent)
     resource = portal_type_to_resource(portal_type)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids that an `Unauthorized` error is raised if the current user has no access to the parent object, but to the current object only.

This happens for client users that have no access to the clients folder.

Traceback:
```
Traceback (most recent call last):
  File "plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 23, in decorator
    return f(*args, **kwargs)
  File "plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 57, in to_json
    return self.dispatch()
  File "plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 51, in dispatch
    return router(self.context, self.request, path)
  File "plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/router.py", line 150, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "senaite.jsonapi/src/senaite/jsonapi/v1/routes/content.py", line 106, in search
    return api.get_batched()
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 113, in get_batched
    complete=complete)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 1626, in get_batch
    endpoint, complete=complete),
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 287, in make_items_for
    return map(extract_data, brains_or_objects)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 282, in extract_data
    info = get_info(brain_or_object, endpoint=endpoint, complete=complete)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 329, in get_info
    parent = get_parent_info(brain_or_object)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 398, in get_parent_info
    parent = get_parent(brain_or_object)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 950, in get_parent
    return get_object_by_path(parent_path)
  File "senaite.jsonapi/src/senaite/jsonapi/api.py", line 1235, in get_object_by_path
    return portal.restrictedTraverse(str(path))
  File "Zope-4.8.2-py2.7.egg/OFS/Traversable.py", line 360, in restrictedTraverse
    return self.unrestrictedTraverse(path, default, restricted=True)
  File "Zope-4.8.2-py2.7.egg/OFS/Traversable.py", line 292, in unrestrictedTraverse
    next = guarded_getattr(obj, name)
Unauthorized: You are not allowed to access 'clients' in this context
```

## Current behavior before PR

`Unauthorized` error is raised when the current user has no access to the parent object

## Desired behavior after PR is merged

Parent object info is omitted if the current user has no permission to access the parent

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
