### PR TITLE
Lookup mapped catalogs for CatalogBrains

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
-- no changes yet
+- #54 Lookup mapped catalogs for CatalogBrains
 
 
 2.4.0 (2023-03-10)

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -45,6 +45,7 @@ class Catalog(object):
     interface.implements(ICatalog)
 
     def __init__(self, context):
+        self.context = context
         self._catalogs = {}
 
     def search(self, query):
@@ -62,7 +63,10 @@ class Catalog(object):
         return self.search(query)
 
     def get_catalog(self):
-        name = req.get("catalog", "portal_catalog")
+        name = req.get("catalog")
+        catalogs = senaiteapi.get_catalogs_for(self.context)
+        if len(catalogs) > 0:
+            name = catalogs[0].getId()
         if name not in self._catalogs:
             # Get the catalog directly from senaite api
             cat = senaiteapi.get_tool(name)

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -64,9 +64,9 @@ class Catalog(object):
 
     def get_catalog(self):
         name = req.get("catalog")
-        catalogs = senaiteapi.get_catalogs_for(self.context)
-        if len(catalogs) > 0:
-            name = catalogs[0].getId()
+        if not name:
+            catalogs = senaiteapi.get_catalogs_for(self.context)
+            name = catalogs[0].getId() if len(catalogs) > 0 else None
         if name not in self._catalogs:
             # Get the catalog directly from senaite api
             cat = senaiteapi.get_tool(name)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds an additional lookup for ZCatalog brains to fetch the right catalog for metadata lookup.

## Current behavior before PR

If no `catalog` request parameter is present, the JSON API always uses `portal_catalog` to fetch the brain metadata.

## Desired behavior after PR is merged

If no `catalog` request parameter is present, the JSON API looks up the mapped catalogs for the portal type and returns the first found catalog from there for metadata lookup.


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
