### PR TITLE
Improved catalog lookup

### DIFF
--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -24,8 +24,6 @@ import json
 
 from AccessControl import Unauthorized
 from Acquisition import ImplicitAcquisitionWrapper
-from senaite.jsonapi.interfaces import IUpdate
-
 from bika.lims import api
 from bika.lims.utils.analysisrequest import create_analysisrequest as create_ar
 from DateTime import DateTime
@@ -43,14 +41,16 @@ from senaite.jsonapi.exceptions import APIError
 from senaite.jsonapi.interfaces import IBatch
 from senaite.jsonapi.interfaces import ICatalog
 from senaite.jsonapi.interfaces import ICatalogQuery
+from senaite.jsonapi.interfaces import ICreate
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IFieldManager
 from senaite.jsonapi.interfaces import IInfo
-from senaite.jsonapi.interfaces import ICreate
+from senaite.jsonapi.interfaces import IUpdate
 from zope.component import getAdapter
+from zope.component import getMultiAdapter
+from zope.component import queryAdapter
 from zope.schema import getFieldNames
 from zope.schema import getFields
-from zope.component import queryAdapter
 
 _marker = object()
 
@@ -579,14 +579,14 @@ def fail(status, msg):
     raise APIError(status, "{}".format(msg))
 
 
-def search(**kw):
+def search(portal_type=None, **kw):
     """Search the catalog adapter
 
     :returns: Catalog search results
     :rtype: iterable
     """
     portal = get_portal()
-    catalog = ICatalog(portal)
+    catalog = getMultiAdapter((portal, portal_type), interface=ICatalog)
     catalog_query = ICatalogQuery(catalog)
     query = catalog_query.make_query(**kw)
     return catalog(query)
@@ -1161,16 +1161,6 @@ def get_endpoint(brain_or_object, default=DEFAULT_ENDPOINT):
         return endpoint_candidates[0]
 
     return default
-
-
-def get_catalog():
-    """Get catalog adapter
-
-    :returns: ICatalog adapter for the Portal
-    :rtype: CatalogTool
-    """
-    portal = get_portal()
-    return ICatalog(portal)
 
 
 def get_object_by_request():

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -43,8 +43,9 @@ class Catalog(object):
     """
     interface.implements(ICatalog)
 
-    def __init__(self, context):
+    def __init__(self, context, portal_type=None):
         self.context = context
+        self.portal_type = portal_type
 
     def search(self, query):
         """search the catalog
@@ -67,7 +68,8 @@ class Catalog(object):
     def get_catalog(self, default="portal_catalog"):
         name = req.get("catalog")
         if not name:
-            catalogs = senaiteapi.get_catalogs_for(self.context)
+            # get the mapped catalog for the given portal_type
+            catalogs = senaiteapi.get_catalogs_for(self.portal_type)
             name = catalogs[0].getId() if len(catalogs) > 0 else default
         return senaiteapi.get_tool(name)
 

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -51,12 +51,10 @@ class Catalog(object):
         """search the catalog
         """
         logger.info("Catalog query={}".format(query))
-        # Support to set the catalog as a request parameter
-        catalogs = _.to_list(req.get("catalog", None))
-        if catalogs:
-            return senaiteapi.search(query, catalog=catalogs)
-        # Delegate to the search API of Bika LIMS
-        return senaiteapi.search(query)
+        catalog = self.get_catalog()
+        if not catalog:
+            return senaiteapi.search(query)
+        return senaiteapi.search(query, catalog=catalog.getId())
 
     def __call__(self, query):
         return self.search(query)

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -20,7 +20,6 @@
 
 from bika.lims import api as senaiteapi
 from DateTime import DateTime
-from plone.memoize import view
 from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
 from senaite.jsonapi import api
 from senaite.jsonapi import logger
@@ -62,7 +61,6 @@ class Catalog(object):
     def __repr__(self):
         return "<Catalog %s>" % self.get_catalog().getId()
 
-    @view.memoize
     def get_catalog(self, default="portal_catalog"):
         name = req.get("catalog")
         if not name:

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -11,9 +11,9 @@
        Unified interface to one or more Portal Catalog tools.
   -->
 
-  <!-- Default catalog adapter -->
+  <!-- Default catalog adapter (context, portal_type) -->
   <adapter
-      for="*"
+      for="* *"
       factory=".catalog.Catalog"
       />
 

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -18,21 +18,19 @@
 # Copyright 2017-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from zope import interface
-from zope import component
-
-from plone.dexterity.interfaces import IDexterityContent
-
 from AccessControl import Unauthorized
+from plone.dexterity.interfaces import IDexterityContent
+from Products.ATContentTypes.interfaces import IATContentType
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.ZCatalog.interfaces import ICatalogBrain
-from Products.ATContentTypes.interfaces import IATContentType
-
 from senaite.jsonapi import api
 from senaite.jsonapi import logger
-from senaite.jsonapi.interfaces import IInfo
 from senaite.jsonapi.interfaces import ICatalog
 from senaite.jsonapi.interfaces import IDataManager
+from senaite.jsonapi.interfaces import IInfo
+from zope import component
+from zope import interface
+from zope.component import getMultiAdapter
 
 _marker = object
 
@@ -143,7 +141,8 @@ class ZCDataProvider(Base):
 
     def __init__(self, context):
         super(ZCDataProvider, self).__init__(context)
-        catalog_adapter = ICatalog(context)
+        catalog_adapter = getMultiAdapter(
+            (context, context.portal_type), interface=ICatalog)
         # extract the metadata
         self.keys = catalog_adapter.get_schema()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary for PR https://github.com/senaite/senaite.jsonapi/pull/54

## Current behavior before PR

Catalog name might be `None` if not found

## Desired behavior after PR is merged

Catalog name defaults to `portal_catalog`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
