### PR TITLE
Fix implicit imports for controlpanel mappings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #56 Fix implicit imports for controlpanel mappings
 - #54 Lookup mapped catalogs for CatalogBrains
 
 

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -29,9 +29,14 @@ from bika.lims.utils.analysisrequest import create_analysisrequest as create_ar
 from DateTime import DateTime
 from plone import api as ploneapi
 from plone.behavior.interfaces import IBehaviorAssignable
+from plone.i18n.interfaces import ILanguageSchema
 from plone.jsonapi.core import router
 from Products.ATContentTypes.utils import DT2dt
-from Products.CMFPlone.controlpanel import browser as cp
+from Products.CMFPlone.interfaces.controlpanel import IDateAndTimeSchema
+from Products.CMFPlone.interfaces.controlpanel import IMailSchema
+from Products.CMFPlone.interfaces.controlpanel import IMaintenanceSchema
+from Products.CMFPlone.interfaces.controlpanel import ISecuritySchema
+from Products.CMFPlone.interfaces.controlpanel import IUserGroupsSettingsSchema
 from Products.CMFPlone.PloneBatch import Batch
 from Products.ZCatalog.Lazy import LazyMap
 from senaite.jsonapi import logger
@@ -57,12 +62,11 @@ _marker = object()
 DEFAULT_ENDPOINT = "senaite.jsonapi.v1.get"
 
 CONTROLPANEL_INTERFACE_MAPPING = {
-    'mail': [cp.mail.IMailSchema],
-    'language': [cp.language.ILanguageSchema],
-    'dateandtime': [cp.dateandtime.IDateAndTimeSchema],
-    'usergroups': [cp.usergroups.IUserGroupsSettingsSchema,
-                   cp.usergroups.ISecuritySchema],
-    'maintenance': [cp.maintenance.IMaintenanceSchema],
+    "mail": [IMailSchema],
+    "language": [ILanguageSchema],
+    "dateandtime": [IDateAndTimeSchema],
+    "usergroups": [IUserGroupsSettingsSchema, ISecuritySchema],
+    "maintenance": [IMaintenanceSchema],
 }
 
 SKIP_UPDATE_FIELDS = ["id", ]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the imports of the `senaite.jsonapi.api` module to include explicit imports for controlpanel mappings

## Current behavior before PR

Implicit imports were used

## Desired behavior after PR is merged

Explicit imports are used

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
