### PR TITLE
Fix search catalog for metadata lookup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #57 Fix search catalog for metadata lookup
 - #56 Fix implicit imports for controlpanel mappings
 - #54 Lookup mapped catalogs for CatalogBrains
 

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -660,12 +660,13 @@ def get_brain(brain_or_object):
 
     # fetch the brain by UID
     uid = get_uid(brain_or_object)
-    uc = get_tool("uid_catalog")
-    results = uc({"UID": uid}) or search(query={'UID': uid})
+    portal_type = api.get_portal_type(brain_or_object)
+    query = {"UID": uid, "portal_type": portal_type}
+    results = api.search(query)
     if len(results) == 0:
         return None
     if len(results) > 1:
-        fail(500, "More than one object with UID={} found in portal_catalog".format(uid))
+        fail(500, "More than one object with UID={}".format(uid))
     return results[0]
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The current PR fixes the metadata lookup when retrieving the full object data.

## Current behavior before PR

UID catalog is always used to fetch a brain from an object for schema lookup.
Although the correct schema fields were queried, all of them were empty (because of the catalog mismatch)

## Desired behavior after PR is merged

Correct catalog is used when searching the brain from an object.
The correct brain metadata is used when retrieving the full object data.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
