### PR TITLE
Fix missing portal type in query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #58 Fix missing portal type in query
 - #57 Fix search catalog for metadata lookup
 - #56 Fix implicit imports for controlpanel mappings
 - #54 Lookup mapped catalogs for CatalogBrains

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -49,6 +49,9 @@ class Catalog(object):
     def search(self, query):
         """search the catalog
         """
+        # always extend the query with the portal_type
+        if self.portal_type:
+            query["portal_type"] = self.portal_type
         logger.info("Catalog query={}".format(query))
         catalog = self.get_catalog()
         if not catalog:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR always adds the `portal_type` to the catalog query if set, e.g. for resource routes.

## Current behavior before PR

Mixed results are returned e.g. for the Analysis Service route:

http://localhost:8080/senaite/@@API/senaite/v1/analysisservice

## Desired behavior after PR is merged

Resource URLs return only requested portal type

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
