### PR TITLE
Fix search route for (multi-) portal type queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #59 Fix search route for (multi-) portal type queries
 - #58 Fix missing portal type in query
 - #57 Fix search catalog for metadata lookup
 - #56 Fix implicit imports for controlpanel mappings

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -590,6 +590,10 @@ def search(portal_type=None, **kw):
     :rtype: iterable
     """
     portal = get_portal()
+    if portal_type is None:
+        if not req.get("portal_type"):
+            return []
+        portal_type = req.get("portal_type")
     catalog = getMultiAdapter((portal, portal_type), interface=ICatalog)
     catalog_query = ICatalogQuery(catalog)
     query = catalog_query.make_query(**kw)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -591,9 +591,8 @@ def search(portal_type=None, **kw):
     """
     portal = get_portal()
     if portal_type is None:
-        if not req.get("portal_type"):
-            return []
-        portal_type = req.get("portal_type")
+        # try to get it over the request
+        portal_type = req.get("portal_type", None)
     catalog = getMultiAdapter((portal, portal_type), interface=ICatalog)
     catalog_query = ICatalogQuery(catalog)
     query = catalog_query.make_query(**kw)

--- a/src/senaite/jsonapi/batch.py
+++ b/src/senaite/jsonapi/batch.py
@@ -18,12 +18,10 @@
 # Copyright 2017-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import urllib
-
-from zope import interface
-
 from senaite.jsonapi import request as req
 from senaite.jsonapi.interfaces import IBatch
+from six.moves.urllib_parse import urlencode
+from zope import interface
 
 
 class Batch(object):
@@ -55,7 +53,7 @@ class Batch(object):
         request = req.get_request()
         params = request.form
         params["b_start"] = self.batch.pagenumber * self.batch.pagesize
-        return "%s?%s" % (request.URL, urllib.urlencode(params))
+        return "%s?%s" % (request.URL, urlencode(params, doseq=True))
 
     def make_prev_url(self):
         if not self.batch.has_previous:
@@ -65,7 +63,7 @@ class Batch(object):
         pagesize = self.batch.pagesize
         pagenumber = self.batch.pagenumber
         params["b_start"] = max(pagenumber - 2, 0) * pagesize
-        return "%s?%s" % (request.URL, urllib.urlencode(params))
+        return "%s?%s" % (request.URL, urlencode(params, doseq=True))
 
 
 class Batch42(object):

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -70,8 +70,9 @@ class Catalog(object):
         if not name:
             catalogs = []
             for portal_type in to_list(self.portal_type):
-                # get the mapped catalog for the given portal_type
+                # Get the mapped catalog for the given portal_type
                 mapped_catalogs = senaiteapi.get_catalogs_for(portal_type)
+                # NOTE: We consider the first mapped catalog as the primary!
                 if len(mapped_catalogs) > 0:
                     catalogs.append(mapped_catalogs[0])
 

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -50,9 +50,13 @@ class Catalog(object):
     def search(self, query):
         """search the catalog
         """
-        # always extend the query with the portal_type
+        # always extend the query with the current portal_type
         if self.portal_type:
             query["portal_type"] = self.portal_type
+        else:
+            # remove the portal_type from the query
+            query.pop("portal_type", None)
+
         logger.info("Catalog query={}".format(query))
         catalog = self.get_catalog()
         if not catalog:
@@ -71,7 +75,8 @@ class Catalog(object):
             catalogs = []
             for portal_type in to_list(self.portal_type):
                 # Get the mapped catalog for the given portal_type
-                mapped_catalogs = senaiteapi.get_catalogs_for(portal_type)
+                mapped_catalogs = senaiteapi.get_catalogs_for(
+                    portal_type, default=default)
                 # NOTE: We consider the first mapped catalog as the primary!
                 if len(mapped_catalogs) > 0:
                     catalogs.append(mapped_catalogs[0])
@@ -82,7 +87,7 @@ class Catalog(object):
             else:
                 name = catalogs[0].getId() if len(catalogs) > 0 else default
 
-        return senaiteapi.get_tool(name)
+        return senaiteapi.get_tool(name, default=default)
 
     def get_schema(self):
         catalog = self.get_catalog()

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import Unauthorized
+from Acquisition import aq_base
 from plone.dexterity.interfaces import IDexterityContent
 from Products.ATContentTypes.interfaces import IATContentType
 from Products.CMFCore.interfaces import ISiteRoot
@@ -42,13 +43,14 @@ class Base(object):
 
     def __init__(self, context):
         self.context = context
+        self.base_context = aq_base(context)
         self.keys = []
         self.ignore = []
 
         # Mapped attributes to extract from the object besides the schema keys.
         # These keys are always included
         self.attributes = {
-            "id": "getId",
+            "id": "_x_get_id",
             "uid": "UID",
             "title": "Title",
             "description": "Description",
@@ -61,6 +63,13 @@ class Base(object):
             "path": "_x_get_physical_path",
             "parent_path": "_x_get_parent_path",
         }
+
+    def _x_get_id(self):
+        """Get The ID w/o acquisition
+
+        This prevents that we get might get the ID from the catalog
+        """
+        return getattr(self.base_context, "id", "")
 
     def _x_get_physical_path(self):
         """Generate the physical path


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the `/@@API/senaite/v1/search` route for single and multi `portal_type` queries.

**☝️ NOTE:** Multi `portal_type` queries where the portal types are indexed in *different catalogs* fall back to a `uid_catalog` query.

## Current behavior before PR

The search route returned the following error:

```json
{
  "_runtime": 0.0009629726409912109,
  "message": "Expected a portal_type string, got <<type 'NoneType'>>",
  "success": false
}
```

## Desired behavior after PR is merged

Search results are returned for multi- and single `portal_type` queries.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
