### PR TITLE
added try catch for schema to prevent attribute error

### DIFF
--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -222,7 +222,10 @@ class ATDataProvider(Base):
 
         # get the schema fields from the data manager
         schema = api.get_schema(context)
-        self.keys = schema.keys()
+        try:
+            self.keys = schema.keys()
+        except AttributeError:
+            self.keys = schema.__dict__.keys()
 
 
 class SiteRootDataProvider(Base):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Trying to get keys from SchemaClass is throwing an error

## Current behavior before PR
Doing queries with complete=True throws an error that `'SchemaClass' object has no attribute 'key'`
Example query `http://localhost:8080/senaite/@@API/senaite/v1/analysisrequest?complete=1`
```json
{"_runtime": 0.13384389877319336, "message": "'SchemaClass' object has no attribute 'keys'", "success": false}
```

## Desired behavior after PR is merged
Querying the AnalysisRequest portal with complete=True is now successfully returning the objects without an error

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
