### PR TITLE
Fix dexterity objects are not validated on creation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #66 Fix dexterity objects are not validated on creation
 - #63 Compatibility with senaite.core#2584 (SampleType to DX)
 - #61 Compatibility with senaite.core#2567 (AnalysisCategory to DX)
 - #61 Compatibility with senaite.core#2471 (Department to DX)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -54,6 +54,7 @@ from senaite.jsonapi.interfaces import IUpdate
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter
+from zope.deprecation import deprecate
 from zope.schema import getFieldNames
 from zope.schema import getFields
 
@@ -1490,7 +1491,7 @@ def update_object_with_data(content, record):
             logger.debug("update_object_with_data::field %r updated", k)
 
     # Validate the entire content object
-    invalid = validate_object(content, record)
+    invalid = api.validate(content)
     if invalid:
         fail(400, u.to_json(invalid))
 
@@ -1505,6 +1506,7 @@ def update_object_with_data(content, record):
     return content
 
 
+@deprecate("Use senaite.core.api.validate instead")
 def validate_object(brain_or_object, data):
     """Validate the entire object
 
@@ -1516,12 +1518,7 @@ def validate_object(brain_or_object, data):
     :rtype: dict
     """
     obj = get_object(brain_or_object)
-
-    # Call the validator of AT Content Types
-    if is_at_content(obj):
-        return obj.validate(data=data)
-
-    return {}
+    return api.validate(obj)
 
 
 def deactivate_object(brain_or_object):

--- a/src/senaite/jsonapi/datamanagers.py
+++ b/src/senaite/jsonapi/datamanagers.py
@@ -226,7 +226,7 @@ class DexterityDataManager(BaseDataManager):
             raise Unauthorized("You are not allowed to modify this content")
 
         # prioritize setters over fields
-        setter = "set{}".format(name.capitalize())
+        setter = "set%s" % (name[0].upper() + name[1:])
         setter = getattr(self.context, setter, None)
         if setter:
             return setter(value)

--- a/src/senaite/jsonapi/tests/doctests/create.rst
+++ b/src/senaite/jsonapi/tests/doctests/create.rst
@@ -128,17 +128,42 @@ If we do a search now for clients, we will get all them:
     [u'TC1', u'TC2', u'TC3', u'TC4', u'TC5', u'TC6']
 
 
-Required fields
-~~~~~~~~~~~~~~~
+Fields validation
+~~~~~~~~~~~~~~~~~
 
 System will fail with a 400 error when trying to create an object without a
-required attribute:
+required attribute (e.g. `Prefix`):
+
+    >>> data = {"portal_type": "SampleType",
+    ...         "parent_path": api.get_path(portal.setup.sampletypes),
+    ...         "MinimumVolume": "20 ml",
+    ...         "title": "Fresh Egg"}
+    >>> post("create", data)
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 400: Bad Request
+
+However, system does not complain if although required, the field has a
+default value defined (e.g. `AdmittedStickerTemplates`):
 
     >>> data = {"portal_type": "SampleType",
     ...         "parent_path": api.get_path(portal.setup.sampletypes),
     ...         "MinimumVolume": "20 ml",
     ...         "title": "Fresh Egg",
     ...         "Prefix": "FE"}
+    >>> post("create", data)
+    '...sampletypes/sampletype-2"...'
+
+Likewise, system will fail when trying to create an object with non-valid data.
+For instance, an error arises if the type of the value is wrong:
+
+
+    >>> data = {"portal_type": "SampleType",
+    ...         "parent_path": api.get_path(portal.setup.sampletypes),
+    ...         "MinimumVolume": "20 ml",
+    ...         "title": "Fresh Egg",
+    ...         "Prefix": "FE",
+    ...         "AdmittedStickerTemplates": "dummy"}
     >>> post("create", data)
     Traceback (most recent call last):
     [...]
@@ -180,7 +205,6 @@ Create a Sample Type
     ...         "parent_path": api.get_path(portal.setup.sampletypes),
     ...         "title": "Fresh Egg",
     ...         "MinimumVolume": "10 gr",
-    ...         "AdmittedStickerTemplates": [{"admitted": ["QR_1x14mmx39mm.pt"], "small_default": ["QR_1x14mmx39mm.pt"], "large_default": ["QR_1x14mmx39mm.pt"]}],
     ...         "Prefix": "FE"}
     >>> sample_type = create(data)
     >>> sample_type.Title()
@@ -300,7 +324,7 @@ instead of the plone's default creation.
     ['Ecoli', 'Sal']
 
     >>> sample.getSampleType()
-    <SampleType at /plone/setup/sampletypes/sampletype-2>
+    <SampleType at /plone/setup/sampletypes/sampletype-4>
 
     >>> sample.getClient()
     <Client at /plone/clients/client-7>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]  
> Merge https://github.com/senaite/senaite.core/pull/2678 first!

This Pull Request ensures that objects from dexterity type are also validated on creation. If the user creates DX objects via `create` endpoint the system now validates that:

- Required fields (without default fallback) have a value set
- Field values are not from the wrong type
- Schema and invariants are checked as well

## Current behavior before PR

DX objects created via `create` end-point were not validated

## Desired behavior after PR is merged

DX objects created via `create` end-point are validated

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
