### PR TITLE
Support for `created_since` and `modified_since` in searches

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -448,6 +448,14 @@ All content resources accept to be filtered by request parameters.
 |                 | this-week, this-month | this date range until today.                                            |
 |                 | this-year             | This uses internally `'range': 'min'` query.                            |
 +-----------------+-----------------------+-------------------------------------------------------------------------+
+| created_since   | %Y-%m-%d %Y%m%d%H%M%S | Specify a since period in `ymd` format or a datetime in a valid ISO     |
+|                 | `2d` (2 days ago)     | format to find all items that were created since that date.             |
+|                 | `2h` (2 hours ago)    | This uses internally `'range': 'min'` query.                            |
++-----------------+-----------------------+-------------------------------------------------------------------------+
+| modified_since  | %Y-%m-%d %Y%m%d%H%M%S | Specify a since period in `ymd` format or a datetime in a valid ISO     |
+|                 | `2d` (2 days ago)     | format to find all items that were modified since that date.            |
+|                 | `2h` (2 hours ago)    | This uses internally `'range': 'min'` query.                            |
++-----------------+-----------------------+-------------------------------------------------------------------------+
 
 .. _Response_Format:
 

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -39,6 +39,7 @@ from Products.CMFPlone.interfaces.controlpanel import ISecuritySchema
 from Products.CMFPlone.interfaces.controlpanel import IUserGroupsSettingsSchema
 from Products.CMFPlone.PloneBatch import Batch
 from Products.ZCatalog.Lazy import LazyMap
+from senaite.core.api import dtime
 from senaite.jsonapi import logger
 from senaite.jsonapi import request as req
 from senaite.jsonapi import underscore as u
@@ -824,6 +825,26 @@ def calculate_delta_date(literal):
     }
     today = DateTime(DateTime().Date())  # current date without the time
     return today - mapping.get(literal, 0)
+
+
+def calculate_since_date(since):
+    """Calculates the "since" date
+
+    Returns the DateTime representing the value passed in. If the value is a
+    duration of time (either an str in `ymd` format or a relativedelta), it
+    calculates the since date using current date time as the end date.
+
+    :param since: A date/datetime-like format or a time interval as ymd format
+    :type since: date/datetime/str/relativedelta
+    :returns: Date when the event started back the period in ymd format
+    :rtype: DateTime
+    """
+    since_dt = dtime.to_DT(since)
+    if since_dt:
+        return since_dt
+
+    since_dt = dtime.get_since_date(since)
+    return dtime.to_DT(since_dt)
 
 
 def is_json_serializable(thing):

--- a/src/senaite/jsonapi/catalog.py
+++ b/src/senaite/jsonapi/catalog.py
@@ -262,6 +262,16 @@ class CatalogQuery(object):
             date = api.calculate_delta_date(recent_modified)
             query["modified"] = {'query': date, 'range': 'min'}
 
+        created_since = req.get_created_since()
+        if created_since:
+            date = api.calculate_since_date(created_since)
+            query["created"] = {"query": date, "range": "min"}
+
+        modified_since = req.get_modified_since()
+        if modified_since:
+            date = api.calculate_since_date(modified_since)
+            query["modified"] = {"query": date, "range": "min"}
+
         return query
 
     def get_keyword_query(self, **kw):

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -204,6 +204,18 @@ def get_recent_modified():
     return get("recent_modified", None)
 
 
+def get_created_since():
+    """Returns the 'created_since' from the request
+    """
+    return get("created_since", None)
+
+
+def get_modified_since():
+    """Returns the `modified_since` from the request
+    """
+    return get("modified_since", None)
+
+
 def get_request_data():
     """ extract and convert the json data from the request
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!WARNING]
> Merge https://github.com/senaite/senaite.core/pull/2695 first!

This Pull Requests adds support for `created_since` and `modified_since` parameters on searches. Both support any of these formats:

- Datetime in ISO and ANSI formats (e.g. `2025-03-01 14:32:23`, `20250301143223`)
- Date in in ISO and ANSI formats format (e.g. `2025-03-01`, `20250301`)
- `ymd` format to express duration. E.g.:
  - `2d`: 2 days ago, 
  - `1d6h`: 1 day and 6 hours ago,
  - `15d`: 15 days ago,
  - `3m`: 3 months ago,
  - ...

Examples:


- Get the samples that were modified since 1 hour ago
  `http://<host>/senaite/@@API/senaite/v1/analysisrequest?modified_since=1h`

- Get the samples that were modified since 1 month ago
  `http://<host>/senaite/@@API/senaite/v1/analysisrequest?modified_since=1m`

- Get the samples that were created since 2 days ago
  `http://<host>/senaite/@@API/senaite/v1/analysisrequest?created_since=2d`

- Get the samples that were created since 1st of January 2025
  `http://<host>/senaite/@@API/senaite/v1/analysisrequest?created_since=20250101`

## Current behavior before PR

Only literals for `recent_modified` and `recent_created` are supported on searches

## Desired behavior after PR is merged

Since-like searches are supported

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
