### PR TITLE
Fix AT field validation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,31 +4,76 @@ on:
   - pull_request
 env:
   PLONE_VERSION: "5.2"
+
 jobs:
   build-and-test:
-    runs-on: 'ubuntu-20.04'
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: cache eggs
-        uses: actions/cache@v3
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache pyenv Python builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.pyenv
+          key: pyenv-2.7.18-${{ runner.os }}
+          restore-keys: |
+            pyenv-2.7.18-
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make build-essential libssl-dev \
+              zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+              wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
+              libxmlsec1-dev libffi-dev liblzma-dev
+
+      - name: Install pyenv
+        run: |
+          if [ ! -d "$HOME/.pyenv" ]; then
+            curl https://pyenv.run | bash
+          fi
+
+      - name: Install Python 2.7 with pyenv (if not cached)
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          pyenv install 2.7.18 || true  # Avoid reinstalling if already cached
+          pyenv global 2.7.18
+
+      - name: Verify Python Version
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          python --version  # Should output Python 2.7.18
+
+      - name: Cache eggs
+        uses: actions/cache@v4
         with:
           key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |
             eggs/
-      - name: install
+
+      - name: Install dependencies and setup virtualenv
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pip install virtualenv
           virtualenv -p `which python` .
-          bin/pip install --upgrade pip
-          bin/pip install -r requirements.txt
-          bin/buildout -N -t 3 annotate
-          bin/buildout -N -t 3
-      - name: lint
+          ./bin/pip install --upgrade pip
+          ./bin/pip install -r requirements.txt
+          ./bin/buildout -N -t 3 annotate
+          ./bin/buildout -N -t 3
+
+      - name: Lint
         run: |
-          bin/pip install flake8
-          bin/flake8 --config ci_flake8.cfg src/senaite/
-      - name: test
+          ./bin/pip install flake8
+          ./bin/flake8 --config ci_flake8.cfg src/senaite/
+
+      - name: Run tests
         run: |
-          bin/test -s senaite.jsonapi
+          ./bin/test -s senaite.jsonapi.tests

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- no changes yet
+- #68 Fix AT field validation
 
 
 2.6.0 (2025-04-04)

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -22,6 +22,7 @@ import copy
 import datetime
 import json
 
+import transaction
 from AccessControl import Unauthorized
 from Acquisition import ImplicitAcquisitionWrapper
 from bika.lims import api
@@ -161,8 +162,15 @@ def create_items(portal_type=None, uid=None, endpoint=None, **kw):
                 portal_type, api.get_path(container)))
 
         # create the object and pass in the record data
-        obj = create_object(container, portal_type, **record)
-        results.append(obj)
+        sp = transaction.savepoint()
+        try:
+            obj = create_object(container, portal_type, **record)
+            results.append(obj)
+        except Exception as e:
+            # rollback the subtransaction if an error occurred
+            # => this ensures that the new generated ID is also rolled back
+            sp.rollback()
+            logger.exception("Error while creating object: %s", e)
 
     if not results:
         fail(400, "No Objects could be created")
@@ -1435,14 +1443,7 @@ def create_object(container, portal_type, **data):
         fail(401, "You are not allowed to create this content")
 
     # Update the object with the given data, but omit the id
-    try:
-        update_object_with_data(obj, data)
-    except APIError:
-        # Failure in creation process, delete the invalid object
-        # NOTE: We bypass the permission checks
-        container._delObject(obj.id)
-        # reraise the error
-        raise
+    update_object_with_data(obj, data)
 
     return obj
 

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -275,6 +275,12 @@ class ATFieldManager(object):
             raise Unauthorized("Field {} is read only."
                                .format(self.name))
 
+        # validate the value
+        error = self.field.validate(value, instance)
+        if error:
+            raise ValueError("Invalid value for field {}: {}"
+                             .format(self.name, error))
+
         # id fields take only strings
         if self.name == "id":
             value = str(value)

--- a/src/senaite/jsonapi/tests/doctests/create.rst
+++ b/src/senaite/jsonapi/tests/doctests/create.rst
@@ -152,7 +152,7 @@ default value defined (e.g. `AdmittedStickerTemplates`):
     ...         "title": "Fresh Egg",
     ...         "Prefix": "FE"}
     >>> post("create", data)
-    '...sampletypes/sampletype-2"...'
+    '...sampletypes/sampletype-1"...'
 
 Likewise, system will fail when trying to create an object with non-valid data.
 For instance, an error arises if the type of the value is wrong:
@@ -164,6 +164,15 @@ For instance, an error arises if the type of the value is wrong:
     ...         "title": "Fresh Egg",
     ...         "Prefix": "FE",
     ...         "AdmittedStickerTemplates": "dummy"}
+    >>> post("create", data)
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 400: Bad Request
+
+    >>> data = {"portal_type": "Client",
+    ...         "parent_path": api.get_path(portal.clients),
+    ...         "Name": "Duplicate Client",
+    ...         "ClientID": "TC1"}
     >>> post("create", data)
     Traceback (most recent call last):
     [...]
@@ -324,7 +333,7 @@ instead of the plone's default creation.
     ['Ecoli', 'Sal']
 
     >>> sample.getSampleType()
-    <SampleType at /plone/setup/sampletypes/sampletype-4>
+    <SampleType at /plone/setup/sampletypes/sampletype-2>
 
     >>> sample.getClient()
     <Client at /plone/clients/client-7>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes missing AT field validation for objectes created by the JSON API.

E.g. it is possible to create two clients with the same `ClientID`.

## Current behavior before PR

No AT field validation is performed.

## Desired behavior after PR is merged

```python
params = {
    "ClientID": "RB",
    "Name": "RIDING BYTES",
    "portal_type": "Client",
    "parent_path": "/senaite/clients"
}
session.post(api_url("create"), params)
```
```json
{
  "_runtime": 0.1545100212097168,
  "message": "Invalid value for field ClientID: Validation failed: 'RB' is not unique",
  "success": false
}
```

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
