### PR TITLE
Implement API for getting geographic subdivisions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -188,6 +188,22 @@ Overview
 +----------+--------------------+----------------------------------------+
 | logout   |                    | De-authenticate                        |
 +----------+--------------------+----------------------------------------+
+| geographic| subdivisions_schema| Geographic subdivisions for countries  |
++----------+--------------------+----------------------------------------+
+
+
+.. _Geographic_Resource:
+
+Geographic Resource
+------------------
+
+The geographic resource provides access to administrative subdivisions (states, provinces, counties, districts) for countries worldwide. This API leverages the `pycountry` library to provide standardized geographic data.
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema
+
+The geographic API supports filtering by country code and administrative depth level. For detailed documentation, see :doc:`geographic`.
+
+.. note:: The geographic API endpoints are publicly accessible and do not require authentication.
 
 
 .. _Catalogs_Resource:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #70 Implement API for getting geographic subdivisions
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation
 

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -10,3 +10,4 @@ Doctests
 .. include:: ../src/senaite/jsonapi/tests/doctests/read.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/update.rst
 .. include:: ../src/senaite/jsonapi/tests/doctests/push.rst
+.. include:: ../src/senaite/jsonapi/tests/doctests/geographic.rst

--- a/docs/geographic.rst
+++ b/docs/geographic.rst
@@ -1,0 +1,342 @@
+Geographic Resource
+==================
+
+The Geographic resource provides access to geographic subdivisions (states, provinces, counties, districts) for countries worldwide. This API leverages the `pycountry` library to provide standardized geographic data.
+
+.. _Geographic_Base_URL:
+
+Base URL
+--------
+
+The geographic routes are available at:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema
+
+.. _Geographic_Overview:
+
+Overview
+--------
+
+The geographic API provides access to administrative subdivisions for countries. It supports two levels of subdivisions:
+
+- **Level 1**: States, provinces, or equivalent first-level administrative divisions
+- **Level 2**: Counties, districts, or equivalent second-level administrative divisions
+
++------------------+--------------------+----------------------------------------+
+| Resource         | Action             | Description                            |
++==================+====================+========================================+
+| geographic       | subdivisions_schema| Geographic subdivisions for countries  |
++------------------+--------------------+----------------------------------------+
+
+.. _Geographic_Parameters:
+
+Parameters
+----------
+
+The geographic API accepts the following request parameters:
+
++-----------------+-----------------------+-------------------------------------------------------------------------+
+| Key             | Value                 | Description                                                             |
++=================+=======================+=========================================================================+
+| country         | ISO 3166-1 alpha-2    | Filter subdivisions by country code (e.g., "US", "ES", "DE")           |
+|                 | country code          | If not provided, returns subdivisions from all countries               |
++-----------------+-----------------------+-------------------------------------------------------------------------+
+| depth           | 0, 1, 2, or negative  | Filter by subdivision depth level                                       |
+|                 |                       | - 0 or omitted: Returns all depths (both 1 and 2)                      |
+|                 |                       | - 1: Returns only level 1 subdivisions (states/provinces)              |
+|                 |                       | - 2: Returns only level 2 subdivisions (counties/districts)            |
+|                 |                       | - Negative values: Returns all depths (same as 0)                      |
++-----------------+-----------------------+-------------------------------------------------------------------------+
+
+.. _Geographic_Usage_Examples:
+
+Usage Examples
+--------------
+
+Get all subdivisions from all countries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns all subdivisions at all depths from all countries:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema
+
+.. code-block:: javascript
+
+    {
+        count: 15000,
+        items: [
+            {
+                code: "US-CA",
+                name: "California",
+                type: "state",
+                country_code: "US",
+                parent_code: "US",
+                parent: "United States",
+                depth: 1
+            },
+            {
+                code: "US-CA-001",
+                name: "Alameda County",
+                type: "county",
+                country_code: "US",
+                parent_code: "US-CA",
+                parent: "California",
+                depth: 2
+            }
+        ],
+        depth: 0,
+        _runtime: 0.123
+    }
+
+Get subdivisions for a specific country
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns all subdivisions for Spain:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema?country=ES
+
+.. code-block:: javascript
+
+    {
+        count: 52,
+        items: [
+            {
+                code: "ES-M",
+                name: "Madrid",
+                type: "province",
+                country_code: "ES",
+                parent_code: "ES",
+                parent: "Spain",
+                depth: 1
+            }
+        ],
+        country: "ES",
+        depth: 0,
+        _runtime: 0.045
+    }
+
+Get level 1 subdivisions only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns only states/provinces for the United States:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema?country=US&depth=1
+
+.. code-block:: javascript
+
+    {
+        count: 50,
+        items: [
+            {
+                code: "US-CA",
+                name: "California",
+                type: "state",
+                country_code: "US",
+                parent_code: "US",
+                parent: "United States",
+                depth: 1
+            }
+        ],
+        country: "US",
+        depth: 1,
+        _runtime: 0.032
+    }
+
+Get level 2 subdivisions only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns only counties/districts for Germany:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema?country=DE&depth=2
+
+.. code-block:: javascript
+
+    {
+        count: 401,
+        items: [
+            {
+                code: "DE-BB-BAR",
+                name: "Barnim",
+                type: "rural district",
+                country_code: "DE",
+                parent_code: "DE-BB",
+                parent: "Brandenburg",
+                depth: 2
+            }
+        ],
+        country: "DE",
+        depth: 2,
+        _runtime: 0.078
+    }
+
+Get all subdivisions at a specific depth (no country filter)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns all level 1 subdivisions from all countries:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema?depth=1
+
+.. code-block:: javascript
+
+    {
+        count: 2500,
+        items: [
+            {
+                code: "US-CA",
+                name: "California",
+                type: "state",
+                country_code: "US",
+                parent_code: "US",
+                parent: "United States",
+                depth: 1
+            },
+            {
+                code: "ES-M",
+                name: "Madrid",
+                type: "province",
+                country_code: "ES",
+                parent_code: "ES",
+                parent: "Spain",
+                depth: 1
+            }
+        ],
+        depth: 1,
+        _runtime: 0.156
+    }
+
+Error handling
+~~~~~~~~~~~~~
+
+When requesting subdivisions for a non-existent country:
+
+    - http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema?country=XX
+
+.. code-block:: javascript
+
+    {
+        count: 0,
+        items: [],
+        error: "Country not found: XX",
+        depth: 0,
+        _runtime: 0.012
+    }
+
+.. _Geographic_Response_Format:
+
+Response Format
+--------------
+
+The geographic API returns a standardized response format:
+
+.. code-block:: javascript
+
+    {
+        count: 52,                    // Number of subdivisions found
+        items: [                      // Array of subdivision objects
+            {
+                code: "ES-M",         // ISO 3166-2 subdivision code
+                name: "Madrid",       // Human-readable subdivision name
+                type: "province",     // Type of administrative division
+                country_code: "ES",   // ISO 3166-1 alpha-2 country code
+                parent_code: "ES",    // Parent subdivision or country code
+                parent: "Spain",      // Human-readable parent name
+                depth: 1              // Administrative level (1 or 2)
+            }
+        ],
+        country: "ES",                // Requested country code (if specified)
+        depth: 1,                     // Requested depth level (if specified)
+        error: "Error message",       // Error message (if applicable)
+        _runtime: 0.045               // Request processing time in seconds
+    }
+
+**count**
+    The number of subdivisions found matching the criteria
+
+**items**
+    Array of subdivision objects with the following fields:
+
+    - **code**: ISO 3166-2 subdivision code (e.g., "US-CA", "ES-M")
+    - **name**: Human-readable subdivision name
+    - **type**: Type of administrative division (e.g., "state", "province", "county")
+    - **country_code**: ISO 3166-1 alpha-2 country code
+    - **parent_code**: Code of the parent subdivision or country
+    - **parent**: Human-readable name of the parent subdivision or country
+    - **depth**: Administrative level (1 for states/provinces, 2 for counties/districts)
+
+**country**
+    The country code that was requested (only present when country parameter is used)
+
+**depth**
+    The depth level that was requested (only present when depth parameter is used)
+
+**error**
+    Error message when the request cannot be fulfilled (e.g., country not found)
+
+**_runtime**
+    The time in seconds needed to process the request
+
+.. _Geographic_Data_Sources:
+
+Data Sources
+-----------
+
+The geographic data is sourced from the `pycountry` library, which provides:
+
+- **ISO 3166-1**: Country codes and names
+- **ISO 3166-2**: Subdivision codes and names
+- **Standardized naming**: Consistent naming conventions across countries
+- **Regular updates**: Updated subdivision data as administrative boundaries change
+
+.. _Geographic_Authentication:
+
+Authentication
+-------------
+
+The geographic API endpoints are **publicly accessible** and do not require authentication. This allows for easy integration with frontend applications and external systems that need geographic data.
+
+.. _Geographic_Performance:
+
+Performance Considerations
+-------------------------
+
+- **Caching**: Geographic data is relatively static and can be cached effectively
+- **Large datasets**: Some countries have many subdivisions (e.g., US has ~3,000 counties)
+- **Filtering**: Use country and depth parameters to limit results and improve performance
+- **Response time**: Typical response times are under 100ms for filtered queries
+
+.. _Geographic_Integration:
+
+Integration Examples
+-------------------
+
+JavaScript example for populating a state dropdown:
+
+.. code-block:: javascript
+
+    fetch('/senaite/@@API/senaite/v1/geographic/subdivisions_schema?country=US&depth=1')
+        .then(response => response.json())
+        .then(data => {
+            const stateSelect = document.getElementById('state');
+            data.items.forEach(state => {
+                const option = document.createElement('option');
+                option.value = state.code;
+                option.textContent = state.name;
+                stateSelect.appendChild(option);
+            });
+        });
+
+Python example for getting subdivisions:
+
+.. code-block:: python
+
+    import requests
+    
+    def get_country_subdivisions(country_code, depth=0):
+        url = f"http://localhost:8080/senaite/@@API/senaite/v1/geographic/subdivisions_schema"
+        params = {"country": country_code, "depth": depth}
+        response = requests.get(url, params=params)
+        return response.json()
+    
+    # Get all Spanish provinces
+    spain_provinces = get_country_subdivisions("ES", depth=1)
+    print(f"Spain has {spain_provinces['count']} provinces") 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Table of Contents:
    quickstart
    auth
    api
+   geographic
    crud
    extend
    doctests

--- a/src/senaite/jsonapi/request.py
+++ b/src/senaite/jsonapi/request.py
@@ -216,6 +216,12 @@ def get_modified_since():
     return get("modified_since", None)
 
 
+def get_country():
+    """Returns the 'country' from the request
+    """
+    return get("country", None)
+
+
 def get_request_data():
     """ extract and convert the json data from the request
 

--- a/src/senaite/jsonapi/tests/doctests/geographic.rst
+++ b/src/senaite/jsonapi/tests/doctests/geographic.rst
@@ -1,0 +1,238 @@
+GEOGRAPHIC
+----------------
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t geographic
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import transaction
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def logout():
+    ...     browser.open(portal_url + "/logout")
+    ...     assert("You are now logged out" in browser.contents)
+
+Variables:
+
+    >>> portal = self.portal
+    >>> portal_url = portal.absolute_url()
+    >>> browser = self.getBrowser()
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+JSON API:
+
+    >>> api_base_url = portal_url + "/@@API/senaite/v1"
+
+
+Get all subdivisions
+~~~~~~~~~~~~~~~~~~~~
+
+The geo_subdivisions route should return all subdivisions at all depths when no
+country is provided:
+
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema")
+    >>> import json
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] > 0
+    True
+    >>> "items" in response
+    True
+    >>> len(response["items"]) > 0
+    True
+    >>> "name" in response["items"][0]
+    True
+    >>> "code" in response["items"][0]
+    True
+    >>> "type" in response["items"][0]
+    True
+    >>> "country_code" in response["items"][0]
+    True
+    >>> "parent_code" in response["items"][0]
+    True
+    >>> "parent" in response["items"][0]
+    True
+    >>> "depth" in response["items"][0]
+    True
+    >>> depths = set(item["depth"] for item in response["items"])
+    >>> 1 in depths
+    True
+    >>> 2 in depths
+    True
+
+
+Get subdivisions for a specific country
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The geo_subdivisions route should return subdivisions for a specific country
+when country is provided:
+
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] > 0
+    True
+    >>> response["country"] == "ES"
+    True
+    >>> response["depth"] == 0
+    True
+    >>> all(item["country_code"] == "ES" for item in response["items"])
+    True
+    >>> "parent" in response["items"][0]
+    True
+
+
+Get subdivisions with depth parameter (no country specified)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The geo_subdivisions route should return subdivisions at a specific depth
+when depth parameter is provided without country:
+
+    # Test depth=1 (level 1 subdivisions only)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?depth=1")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> all(item["depth"] == 1 for item in response["items"])
+    True
+
+    # Test depth=2 (level 2 subdivisions only)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?depth=2")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> all(item["depth"] == 2 for item in response["items"])
+    True
+
+
+Get subdivisions with depth parameter (country specified)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The geo_subdivisions route should return subdivisions at a specific depth
+when depth parameter is provided with country:
+
+    # Test depth=0 (returns all subdivisions - depth 1 + depth 2)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=0")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> response["country"] == "ES"
+    True
+    >>> response["depth"] == 0
+    True
+    >>> "depth" in response["items"][0]
+    True
+
+    # Test depth=1 (level 1 subdivisions - states/provinces)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=1")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> response["country"] == "ES"
+    True
+    >>> response["depth"] == 1
+    True
+    >>> all(item["depth"] == 1 for item in response["items"])
+    True
+
+    # Test depth=2 (level 2 subdivisions - counties/districts)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=2")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> response["country"] == "ES"
+    True
+    >>> response["depth"] == 2
+    True
+    >>> all(item["depth"] == 2 for item in response["items"])
+    True
+
+    # Test negative depth (returns all subdivisions - depth 1 + depth 2)
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=-1")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> response["country"] == "ES"
+    True
+    >>> response["depth"] is None
+    True
+    >>> "depth" in response["items"][0]
+    True
+
+
+Get subdivisions for non-existent country
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The geo_subdivisions route should return an error for non-existent countries:
+
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=XX")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] == 0
+    True
+    >>> "error" in response
+    True
+    >>> "Country not found" in response["error"]
+    True
+
+
+Get subdivisions for US with depth 2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test getting subdivisions for US at depth 2 (states and counties):
+
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=US&depth=2")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] >= 0
+    True
+    >>> response["country"] == "US"
+    True
+    >>> response["depth"] == 2
+    True
+    >>> all(item["depth"] == 2 for item in response["items"])
+    True
+
+
+Test parent_code logic
+~~~~~~~~~~~~~~~~~~~~~
+
+Test that parent_code is correctly set based on depth:
+
+    # Level 1 subdivisions should have country_code as parent_code
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=1")
+    >>> response = json.loads(browser.contents)
+    >>> if response["count"] > 0:
+    ...     level1_item = response["items"][0]
+    ...     level1_item["parent_code"] == level1_item["country_code"]
+    True
+
+    # Level 2 subdivisions should have their actual parent_code
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES&depth=2")
+    >>> response = json.loads(browser.contents)
+    >>> if response["count"] > 0:
+    ...     level2_item = response["items"][0]
+    ...     level2_item["parent_code"] != level2_item["country_code"]
+    True
+
+
+Unauthenticated user
+~~~~~~~~~~~~~~~~~~~~
+
+Log out:
+
+    >>> logout()
+
+The geo_subdivisions route should be accessible to unauthenticated users:
+
+    >>> browser.open(api_base_url + "/geographic/subdivisions_schema?country=ES")
+    >>> response = json.loads(browser.contents)
+    >>> response["count"] > 0
+    True 

--- a/src/senaite/jsonapi/v1/routes/geographic.py
+++ b/src/senaite/jsonapi/v1/routes/geographic.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.jsonapi import add_route
+from senaite.jsonapi import request as req
+from senaite.core.api import geo
+
+
+def create_subdivision_dict(
+    subdivision, parent_name, depth,
+):
+    """
+    Create a standardized subdivision dictionary
+    """
+    return {
+        "code": subdivision.code,
+        "name": subdivision.name,
+        "type": subdivision.type,
+        "country_code": subdivision.country_code,
+        "parent_code": (
+            subdivision.parent_code
+            if depth == 2 else subdivision.country_code
+        ),
+        "parent": parent_name,
+        "depth": depth,
+    }
+
+
+def get_level2_subdivisions(level1_subdivision):
+    """
+    Get level 2 subdivisions for a given level 1 subdivision
+    """
+    return geo.get_subdivisions(level1_subdivision, default=[])
+
+
+def get_all_subdivisions(depth=None):
+    """
+    Get all subdivisions from all countries at specified depth
+    """
+    countries = geo.get_countries()
+    all_subdivisions = []
+
+    for country in countries:
+        # Get level 1 subdivisions (states/provinces)
+        level1_subdivisions = geo.get_subdivisions(country, default=[])
+        for subdivision in level1_subdivisions:
+            # Only add level 1 if depth is None, 0, or 1
+            if depth is None or depth == 0 or depth == 1:
+                all_subdivisions.append(
+                    create_subdivision_dict(
+                        subdivision=subdivision,
+                        parent_name=country.name,
+                        depth=1,
+                    )
+                )
+
+            # Get level 2 subdivisions (counties/districts) for this
+            # subdivision
+            # Only add level 2 if depth is None, 0, or 2
+            if depth is None or depth == 0 or depth == 2:
+                level2_subdivisions = get_level2_subdivisions(subdivision)
+                for sub_subdivision in level2_subdivisions:
+                    all_subdivisions.append(
+                        create_subdivision_dict(
+                            subdivision=sub_subdivision,
+                            parent_name=subdivision.name,
+                            depth=2,
+                        )
+                    )
+
+    return all_subdivisions
+
+
+def get_country_subdivisions(country_code, depth):
+    """
+    Get subdivisions for a specific country and depth
+    """
+    # Get country by code
+    geo_country = geo.get_country(country_code, default=None)
+    if not geo_country:
+        return {
+            "count": 0,
+            "items": [],
+            "error": "Country not found: {}".format(country_code),
+            "depth": None if depth < 0 else depth,
+        }
+
+    # Get level 1 subdivisions for the country
+    level1_subdivisions = geo.get_subdivisions(country_code, default=[])
+    items = []
+
+    if depth == 1:
+        # Only level 1 subdivisions
+        for subdivision in level1_subdivisions:
+            items.append(
+                create_subdivision_dict(
+                    subdivision=subdivision,
+                    parent_name=geo_country.name,
+                    depth=1,
+                )
+            )
+    elif depth == 2:
+        # Only level 2 subdivisions
+        for subdivision in level1_subdivisions:
+            level2_subdivisions = get_level2_subdivisions(subdivision)
+            for sub_subdivision in level2_subdivisions:
+                items.append(
+                    create_subdivision_dict(
+                        subdivision=sub_subdivision,
+                        parent_name=subdivision.name,
+                        depth=2,
+                    )
+                )
+    else:
+        # All depths (both 1 and 2)
+        for subdivision in level1_subdivisions:
+            items.append(
+                create_subdivision_dict(
+                    subdivision=subdivision,
+                    parent_name=geo_country.name,
+                    depth=1,
+                )
+            )
+            level2_subdivisions = get_level2_subdivisions(subdivision)
+            for sub_subdivision in level2_subdivisions:
+                items.append(
+                    create_subdivision_dict(
+                        subdivision=sub_subdivision,
+                        parent_name=subdivision.name,
+                        depth=2,
+                    )
+                )
+
+    return {
+        "count": len(items),
+        "items": items,
+        "country": country_code,
+        "depth": None if depth < 0 else depth,
+    }
+
+
+@add_route("/senaite/v1",
+           "senaite.jsonapi.v1.geographic", methods=["GET"])
+@add_route("/senaite/v1/geographic/subdivisions_schema",
+           "senaite.jsonapi.v1.geographic", methods=["GET"])
+def get(context, request):
+    """
+    Get subdivisions based on the country code
+        <Plonesite>/@@API/v1/geographic/subdivisions_schema
+            ->returns all subdivisions
+        <Plonesite>/@@API/v1/geographic/subdivisions_schema?country=Code
+            ->returns only that country
+        <Plonesite>/@@API/v1/geographic/subdivisions_schema?country=Code&depth=Level
+            ->returns only that country and depth
+        <Plonesite>/@@API/v1/geographic/subdivisions_schema?depth=Level
+            ->returns all subdivisions at specified depth
+    """
+    country = req.get_country()
+    depth = req.get_depth()
+
+    # If no country provided, return all subdivisions at specified depth
+    if not country:
+        all_subdivisions = get_all_subdivisions(depth)
+        return {
+            "count": len(all_subdivisions),
+            "items": all_subdivisions,
+            "depth": None if depth < 0 else depth,
+        }
+
+    # Get subdivisions for specific country and depth
+    return get_country_subdivisions(country, depth)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR implements a new geographic subdivisions API endpoint for SENAITE JSON API that provides access to geographic data (states/provinces, and counties/districts)

## Current behavior before PR
Did not provide a dedicated endpoint for geographic subdivisions. Clients requiring geographic data would need to:

- Use the existing address widget's AJAX endpoint which has limited functionality
- Access geographic information only through the core geo API functions directly

## Desired behavior after PR is merged
Have access to a comprehensive geographic subdivisions API with the following capabilities:
API Endpoints:

- GET /senaite/v1/geographic/subdivisions_schema - Returns all subdivisions
- GET /senaite/v1/geographic/subdivisions_schema?country=CODE - Returns subdivisions for specific country
- GET /senaite/v1/geographic/subdivisions_schema?depth=LEVEL - Returns subdivisions at specific depth
- GET /senaite/v1/geographic/subdivisions_schema?country=CODE&depth=LEVEL - Returns filtered subdivisions

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
