### PR TITLE
Fix skipping warning for none return setters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #71 Fix logging issue for skipped fields with None-returning setters
+- #72 Fix logging issue for skipped fields with None-returning setters
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #71 Fix logging issue for skipped fields with None-returning setters
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation
 

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1523,8 +1523,8 @@ def update_object_with_data(content, record):
             except ValueError, exc:
                 fail(400, str(exc))
 
-            if not success:
-                logger.warn("update_object_with_data::skipping key=%r", k)
+            if success is False:
+                logger.warning("update_object_with_data::skipping key=%r", k)
                 continue
 
             logger.debug("update_object_with_data::field %r updated", k)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

address the issue #71 

## Current behavior before PR

Most base field setters do not return any value. This leads to the "field skipped" message being logged, even though the setter was executed properly and the new value was set to the field.

## Desired behavior after PR is merged

no warnings for None return setters

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
