### PR TITLE
Update setter method name generation in DexterityDataManager

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #73 Update setter method name generation in DexterityDataManager
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation
 

--- a/src/senaite/jsonapi/datamanagers.py
+++ b/src/senaite/jsonapi/datamanagers.py
@@ -226,11 +226,8 @@ class DexterityDataManager(BaseDataManager):
             raise Unauthorized("You are not allowed to modify this content")
 
         # prioritize setters over fields
-        parts = name.split("_")
-        setter = "set%s" % "".join(
-            p[:1].upper() + p[1:] for p in parts if p
-        )
-        setter = getattr(self.context, setter, None)
+        setter = "".join([part.capitalize() for part in name.split("_")])
+        setter = getattr(self.context, "set%s" % setter, None)
         if setter:
             return setter(value)
 

--- a/src/senaite/jsonapi/datamanagers.py
+++ b/src/senaite/jsonapi/datamanagers.py
@@ -226,7 +226,10 @@ class DexterityDataManager(BaseDataManager):
             raise Unauthorized("You are not allowed to modify this content")
 
         # prioritize setters over fields
-        setter = "set%s" % (name[0].upper() + name[1:])
+        parts = name.split("_")
+        setter = "set%s" % "".join(
+            p[:1].upper() + p[1:] for p in parts if p
+        )
         setter = getattr(self.context, setter, None)
         if setter:
             return setter(value)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR fixes Dexterity JSON API updates that currently miss context setters when the field name contains underscores, because the generated setter name stops at setFoo_bar instead of matching the camel-cased method that Dexterity content types expose

## Current behavior before PR
DexterityDataManager only uppercases the very first character of an incoming field name, so setters like setAdditionalPhoneNumbers is never invoked for additional_phone_numbers

## Desired behavior after PR is merged
Setter names are now created by camel-casing snake_case field names (e.g. additional_phone_numbers → setAdditionalPhoneNumbers), ensuring Dexterity setters are discovered and their validation or side effects run during JSON API updates.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
