### PR TITLE
Fix regression with #73

### DIFF
--- a/src/senaite/jsonapi/datamanagers.py
+++ b/src/senaite/jsonapi/datamanagers.py
@@ -226,7 +226,7 @@ class DexterityDataManager(BaseDataManager):
             raise Unauthorized("You are not allowed to modify this content")
 
         # prioritize setters over fields
-        setter = "".join([part.capitalize() for part in name.split("_")])
+        setter = "".join(pt[:1].upper() + pt[1:] for pt in name.split("_"))
         setter = getattr(self.context, "set%s" % setter, None)
         if setter:
             return setter(value)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an issue introduced with #73 as per https://github.com/senaite/senaite.jsonapi/pull/73#discussion_r2381245006

## Current behavior before PR

Camelcase field names like "MinimumVolume" are converted to "Minimumvolume"

## Desired behavior after PR is merged

Camelcase field names like "MinimumVolume" are preserved

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
