### PR TITLE
Fix to encode UTF-8 to pass UIDReferenceField validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #75 Fix to encode UTF-8 to pass UIDReferenceField validation
 - #73 Update setter method name generation in DexterityDataManager
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -28,6 +28,7 @@ from senaite.jsonapi import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import underscore as u
 from senaite.jsonapi.interfaces import IFieldManager
+from senaite.jsonapi.utils import to_utf8
 from zope import interface
 from zope.interface import implementer
 from zope.schema._bootstrapinterfaces import WrongContainedType
@@ -619,6 +620,7 @@ class UIDReferenceFieldMixin(object):
 
         # Always handle the value as a list
         values = u.to_list(value)
+        values = to_utf8(values)
 
         for v in values:
             if api.is_uid(v):

--- a/src/senaite/jsonapi/utils.py
+++ b/src/senaite/jsonapi/utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import six
+
+
+def to_utf8(value):
+    if isinstance(value, six.text_type):
+        return value.encode("utf-8")
+    elif isinstance(value, list):
+        return map(to_utf8, value)
+    elif isinstance(value, dict):
+        return {
+            to_utf8(key): to_utf8(value)
+            for key, value in six.iteritems(value)
+        }
+    return value


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Fix validation in `fieldmanagers.py` where UIDReferenceField fails, because the field is returned as a string instead of unicode.

## Current behavior before PR
Validation fails for `UIDReferenceField` due to type mismatch (string vs unicode).

## Desired behavior after PR is merged
Validation passes correctly for `UIDReferenceField` without raising type errors.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
