### PR TITLE
Support multiple IInfo adapters per content type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #76 Support multiple IInfo adapters per content type
 - #73 Update setter method name generation in DexterityDataManager
 - #69 Allow to pass in physical paths for create/update endpoints
 - #68 Fix AT field validation

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -1664,7 +1664,7 @@ def get_info_interfaces(brain_or_object):
     """Get the appropriate info interfaces for the given object
     """
     interfaces = [IInfo]  # Always include the base interface for backward compatibility
-    
+
     if is_brain(brain_or_object):
         interfaces.append(ICatalogBrainInfo)
     elif is_root(brain_or_object):
@@ -1673,7 +1673,7 @@ def get_info_interfaces(brain_or_object):
         interfaces.append(IDexterityContentInfo)
     elif is_at_content(brain_or_object):
         interfaces.append(IATContentInfo)
-    
+
     return interfaces
 
 # -----------------------------------------------------------------------------

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -52,10 +52,6 @@ from senaite.jsonapi.interfaces import ICreate
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IFieldManager
 from senaite.jsonapi.interfaces import IInfo
-from senaite.jsonapi.interfaces import ICatalogBrainInfo
-from senaite.jsonapi.interfaces import IDexterityContentInfo
-from senaite.jsonapi.interfaces import IATContentInfo
-from senaite.jsonapi.interfaces import ISiteRootInfo
 from senaite.jsonapi.interfaces import IUpdate
 from zope.component import getAdapter
 from zope.component import getAdapters
@@ -272,7 +268,11 @@ def delete_items(portal_type=None, uid=None, endpoint=None, **kw):
     for obj in objects:
         # We deactivate only!
         deactivate_object(obj)
-        info = IInfo(obj)()
+
+        # Extract the data with proper adapters
+        info = {}
+        for name, adapter in getAdapters((obj,), IInfo):
+            info.update(adapter.to_dict())
         results.append(info)
 
     if not results:
@@ -337,8 +337,10 @@ def get_info(brain_or_object, endpoint=None, complete=False):
         logger.warn("Skipping relationship object {}".format(repr(brain_or_object)))
         return {}
 
-    # extract the data from the initial object with the proper adapter
-    info = IInfo(brain_or_object).to_dict()
+    # extract the data from the initial object with proper adapters
+    info = {}
+    for name, adapter in getAdapters((brain_or_object, ), IInfo):
+        info.update(adapter.to_dict())
 
     # update with url info (always included)
     url_info = get_url_info(brain_or_object, endpoint)
@@ -354,10 +356,9 @@ def get_info(brain_or_object, endpoint=None, complete=False):
         # ensure we have a full content object
         obj = api.get_object(brain_or_object)
 
-        obj_interfaces = get_info_interfaces(obj)
-        for interface in obj_interfaces:
-            for name, adapter in getAdapters((obj, ), interface):
-                info.update(adapter.to_dict())
+        # updates the dict representation with info from custom adapters
+        for name, adapter in getAdapters((obj, ), IInfo):
+            info.update(adapter.to_dict())
 
         # update the data set with the workflow information
         # -> only possible if `?complete=yes&workflow=yes`
@@ -1659,22 +1660,6 @@ def get_settings_from_interface(iface):
             settings[schema_id][setting] = value
     return settings
 
-
-def get_info_interfaces(brain_or_object):
-    """Get the appropriate info interfaces for the given object
-    """
-    interfaces = [IInfo]  # Always include the base interface for backward compatibility
-
-    if is_brain(brain_or_object):
-        interfaces.append(ICatalogBrainInfo)
-    elif is_root(brain_or_object):
-        interfaces.append(ISiteRootInfo)
-    elif is_dexterity_content(brain_or_object):
-        interfaces.append(IDexterityContentInfo)
-    elif is_at_content(brain_or_object):
-        interfaces.append(IATContentInfo)
-
-    return interfaces
 
 # -----------------------------------------------------------------------------
 #   Batching Helpers

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -52,8 +52,13 @@ from senaite.jsonapi.interfaces import ICreate
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IFieldManager
 from senaite.jsonapi.interfaces import IInfo
+from senaite.jsonapi.interfaces import ICatalogBrainInfo
+from senaite.jsonapi.interfaces import IDexterityContentInfo
+from senaite.jsonapi.interfaces import IATContentInfo
+from senaite.jsonapi.interfaces import ISiteRootInfo
 from senaite.jsonapi.interfaces import IUpdate
 from zope.component import getAdapter
+from zope.component import getAdapters
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter
 from zope.deprecation import deprecate
@@ -348,10 +353,11 @@ def get_info(brain_or_object, endpoint=None, complete=False):
     if complete:
         # ensure we have a full content object
         obj = api.get_object(brain_or_object)
-        # get the compatible adapter
-        adapter = IInfo(obj)
-        # update the data set with the complete information
-        info.update(adapter.to_dict())
+
+        obj_interfaces = get_info_interfaces(obj)
+        for interface in obj_interfaces:
+            for name, adapter in getAdapters((obj, ), interface):
+                info.update(adapter.to_dict())
 
         # update the data set with the workflow information
         # -> only possible if `?complete=yes&workflow=yes`
@@ -1652,6 +1658,23 @@ def get_settings_from_interface(iface):
         if is_json_serializable(value):
             settings[schema_id][setting] = value
     return settings
+
+
+def get_info_interfaces(brain_or_object):
+    """Get the appropriate info interfaces for the given object
+    """
+    interfaces = [IInfo]  # Always include the base interface for backward compatibility
+    
+    if is_brain(brain_or_object):
+        interfaces.append(ICatalogBrainInfo)
+    elif is_root(brain_or_object):
+        interfaces.append(ISiteRootInfo)
+    elif is_dexterity_content(brain_or_object):
+        interfaces.append(IDexterityContentInfo)
+    elif is_at_content(brain_or_object):
+        interfaces.append(IATContentInfo)
+    
+    return interfaces
 
 # -----------------------------------------------------------------------------
 #   Batching Helpers

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -31,8 +31,9 @@
 
   <!-- Default data provider (AT based content types) -->
   <adapter
-      for="*"
+      for="Products.ATContentTypes.interfaces.IATContentType"
       provides=".interfaces.IATContentInfo"
+      name="senaite.jsonapi.dataproviders.ATDataProvider"
       factory=".dataproviders.ATDataProvider"
       />
 
@@ -40,6 +41,7 @@
   <adapter
       for="Products.ZCatalog.interfaces.ICatalogBrain"
       provides=".interfaces.ICatalogBrainInfo"
+      name="senaite.jsonapi.dataproviders.ZCDataProvider"
       factory=".dataproviders.ZCDataProvider"
       />
 
@@ -47,6 +49,7 @@
   <adapter
       for="Products.CMFCore.interfaces.ISiteRoot"
       provides=".interfaces.ISiteRootInfo"
+      name="senaite.jsonapi.dataproviders.SiteRootDataProvider"
       factory=".dataproviders.SiteRootDataProvider"
       />
 
@@ -54,6 +57,7 @@
   <adapter
       for="plone.dexterity.interfaces.IDexterityContent"
       provides=".interfaces.IDexterityContentInfo"
+      name="senaite.jsonapi.dataproviders.DexterityDataProvider"
       factory=".dataproviders.DexterityDataProvider"
       />
 

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -31,32 +31,24 @@
 
   <!-- Default data provider (AT based content types) -->
   <adapter
-      for="Products.ATContentTypes.interfaces.IATContentType"
-      provides=".interfaces.IATContentInfo"
       name="senaite.jsonapi.dataproviders.ATDataProvider"
       factory=".dataproviders.ATDataProvider"
       />
 
   <!-- Adapter for Catalog Brains -->
   <adapter
-      for="Products.ZCatalog.interfaces.ICatalogBrain"
-      provides=".interfaces.ICatalogBrainInfo"
       name="senaite.jsonapi.dataproviders.ZCDataProvider"
       factory=".dataproviders.ZCDataProvider"
       />
 
   <!-- Adapter for the Plone Site -->
   <adapter
-      for="Products.CMFCore.interfaces.ISiteRoot"
-      provides=".interfaces.ISiteRootInfo"
       name="senaite.jsonapi.dataproviders.SiteRootDataProvider"
       factory=".dataproviders.SiteRootDataProvider"
       />
 
   <!-- Data provider for Dexterity content types -->
   <adapter
-      for="plone.dexterity.interfaces.IDexterityContent"
-      provides=".interfaces.IDexterityContentInfo"
       name="senaite.jsonapi.dataproviders.DexterityDataProvider"
       factory=".dataproviders.DexterityDataProvider"
       />

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -32,24 +32,28 @@
   <!-- Default data provider (AT based content types) -->
   <adapter
       for="*"
+      provides=".interfaces.IATContentInfo"
       factory=".dataproviders.ATDataProvider"
       />
 
   <!-- Adapter for Catalog Brains -->
   <adapter
       for="Products.ZCatalog.interfaces.ICatalogBrain"
+      provides=".interfaces.ICatalogBrainInfo"
       factory=".dataproviders.ZCDataProvider"
       />
 
   <!-- Adapter for the Plone Site -->
   <adapter
       for="Products.CMFCore.interfaces.ISiteRoot"
+      provides=".interfaces.ISiteRootInfo"
       factory=".dataproviders.SiteRootDataProvider"
       />
 
   <!-- Data provider for Dexterity content types -->
   <adapter
       for="plone.dexterity.interfaces.IDexterityContent"
+      provides=".interfaces.IDexterityContentInfo"
       factory=".dataproviders.DexterityDataProvider"
       />
 

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -148,6 +148,7 @@ class Base(object):
 class ZCDataProvider(Base):
     """ Catalog Brain Adapter
     """
+    interface.implements(IInfo)
     component.adapts(ICatalogBrain)
 
     def __init__(self, context):
@@ -198,6 +199,7 @@ class ZCDataProvider(Base):
 class DexterityDataProvider(Base):
     """ Data Provider for Dexterity based content types
     """
+    interface.implements(IInfo)
     component.adapts(IDexterityContent)
 
     def __init__(self, context):
@@ -212,6 +214,7 @@ class DexterityDataProvider(Base):
 class ATDataProvider(Base):
     """ Archetypes Adapter
     """
+    interface.implements(IInfo)
     component.adapts(IBaseObject)
 
     def __init__(self, context):
@@ -225,6 +228,7 @@ class ATDataProvider(Base):
 class SiteRootDataProvider(Base):
     """ Site Root Adapter
     """
+    interface.implements(IInfo)
     component.adapts(ISiteRoot)
 
     def __init__(self, context):

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -21,7 +21,7 @@
 from AccessControl import Unauthorized
 from Acquisition import aq_base
 from plone.dexterity.interfaces import IDexterityContent
-from Products.ATContentTypes.interfaces import IATContentType
+from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.ZCatalog.interfaces import ICatalogBrain
 from senaite.jsonapi import api
@@ -212,7 +212,7 @@ class DexterityDataProvider(Base):
 class ATDataProvider(Base):
     """ Archetypes Adapter
     """
-    component.adapts(IATContentType)
+    component.adapts(IBaseObject)
 
     def __init__(self, context):
         super(ATDataProvider, self).__init__(context)

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -29,6 +29,10 @@ from senaite.jsonapi import logger
 from senaite.jsonapi.interfaces import ICatalog
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IInfo
+from senaite.jsonapi.interfaces import ICatalogBrainInfo
+from senaite.jsonapi.interfaces import IDexterityContentInfo
+from senaite.jsonapi.interfaces import IATContentInfo
+from senaite.jsonapi.interfaces import ISiteRootInfo
 from zope import component
 from zope import interface
 from zope.component import getMultiAdapter
@@ -148,7 +152,7 @@ class Base(object):
 class ZCDataProvider(Base):
     """ Catalog Brain Adapter
     """
-    interface.implements(IInfo)
+    interface.implements(ICatalogBrainInfo)
     component.adapts(ICatalogBrain)
 
     def __init__(self, context):
@@ -199,7 +203,7 @@ class ZCDataProvider(Base):
 class DexterityDataProvider(Base):
     """ Data Provider for Dexterity based content types
     """
-    interface.implements(IInfo)
+    interface.implements(IDexterityContentInfo)
     component.adapts(IDexterityContent)
 
     def __init__(self, context):
@@ -214,7 +218,7 @@ class DexterityDataProvider(Base):
 class ATDataProvider(Base):
     """ Archetypes Adapter
     """
-    interface.implements(IInfo)
+    interface.implements(IATContentInfo)
     component.adapts(IATContentType)
 
     def __init__(self, context):
@@ -228,7 +232,7 @@ class ATDataProvider(Base):
 class SiteRootDataProvider(Base):
     """ Site Root Adapter
     """
-    interface.implements(IInfo)
+    interface.implements(ISiteRootInfo)
     component.adapts(ISiteRoot)
 
     def __init__(self, context):

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -29,10 +29,6 @@ from senaite.jsonapi import logger
 from senaite.jsonapi.interfaces import ICatalog
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IInfo
-from senaite.jsonapi.interfaces import ICatalogBrainInfo
-from senaite.jsonapi.interfaces import IDexterityContentInfo
-from senaite.jsonapi.interfaces import IATContentInfo
-from senaite.jsonapi.interfaces import ISiteRootInfo
 from zope import component
 from zope import interface
 from zope.component import getMultiAdapter
@@ -152,7 +148,6 @@ class Base(object):
 class ZCDataProvider(Base):
     """ Catalog Brain Adapter
     """
-    interface.implements(ICatalogBrainInfo)
     component.adapts(ICatalogBrain)
 
     def __init__(self, context):
@@ -203,7 +198,6 @@ class ZCDataProvider(Base):
 class DexterityDataProvider(Base):
     """ Data Provider for Dexterity based content types
     """
-    interface.implements(IDexterityContentInfo)
     component.adapts(IDexterityContent)
 
     def __init__(self, context):
@@ -218,7 +212,6 @@ class DexterityDataProvider(Base):
 class ATDataProvider(Base):
     """ Archetypes Adapter
     """
-    interface.implements(IATContentInfo)
     component.adapts(IATContentType)
 
     def __init__(self, context):
@@ -232,7 +225,6 @@ class ATDataProvider(Base):
 class SiteRootDataProvider(Base):
     """ Site Root Adapter
     """
-    interface.implements(ISiteRootInfo)
     component.adapts(ISiteRoot)
 
     def __init__(self, context):

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -33,6 +33,7 @@ class IInfo(interface.Interface):
         """ return the dictionary representation of the object
         """
 
+
 class IDataManager(interface.Interface):
     """ Field Interface
     """

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -34,6 +34,26 @@ class IInfo(interface.Interface):
         """
 
 
+class ICatalogBrainInfo(IInfo):
+    """ JSON Info Interface for Catalog Brains
+    """
+
+
+class IDexterityContentInfo(IInfo):
+    """ JSON Info Interface for Dexterity Content
+    """
+
+
+class IATContentInfo(IInfo):
+    """ JSON Info Interface for Archetypes Content
+    """
+
+
+class ISiteRootInfo(IInfo):
+    """ JSON Info Interface for Site Root
+    """
+
+
 class IDataManager(interface.Interface):
     """ Field Interface
     """

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -33,27 +33,6 @@ class IInfo(interface.Interface):
         """ return the dictionary representation of the object
         """
 
-
-class ICatalogBrainInfo(IInfo):
-    """ JSON Info Interface for Catalog Brains
-    """
-
-
-class IDexterityContentInfo(IInfo):
-    """ JSON Info Interface for Dexterity Content
-    """
-
-
-class IATContentInfo(IInfo):
-    """ JSON Info Interface for Archetypes Content
-    """
-
-
-class ISiteRootInfo(IInfo):
-    """ JSON Info Interface for Site Root
-    """
-
-
 class IDataManager(interface.Interface):
     """ Field Interface
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR addresses the limitation in senaite.jsonapi where only one IInfo adapter per content type could be effectively used.

## Current behavior before PR

- Only the most specific `IInfo` adapter is used per content type
- Multiple add-ons registering `IInfo` adapters for the same content type will conflict
- The most specific adapter gets used while others are ignored

## Desired behavior after PR is merged
Content-type-specific interfaces allow targeted adapter registration:

- ICatalogBrainInfo for catalog brain objects
- IDexterityContentInfo for Dexterity content
- IATContentInfo for Archetypes content
- ISiteRootInfo for site root objects

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
