### PR TITLE
Include object version in JSON response

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #77 Include object version in JSON response
 - #76 Support multiple IInfo adapters per content type
 - #72 Fix logging issue for skipped fields with None-returning setters
 - #73 Update setter method name generation in DexterityDataManager

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -26,6 +26,7 @@ import transaction
 from AccessControl import Unauthorized
 from Acquisition import ImplicitAcquisitionWrapper
 from bika.lims import api
+from bika.lims.api import snapshot
 from bika.lims.utils.analysisrequest import create_analysisrequest as create_ar
 from DateTime import DateTime
 from plone import api as ploneapi
@@ -359,6 +360,9 @@ def get_info(brain_or_object, endpoint=None, complete=False):
         # updates the dict representation with info from custom adapters
         for name, adapter in getAdapters((obj, ), IInfo):
             info.update(adapter.to_dict())
+
+        # add the snapshot version of this content
+        info["version"] = snapshot.get_version(obj)
 
         # update the data set with the workflow information
         # -> only possible if `?complete=yes&workflow=yes`


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the `version` of the object in the json representation of the requested resource when `complete=1` is used or when the `UID` is used as the resource.

## Current behavior before PR

The `json` representation of the resource does not come with the `version`

## Desired behavior after PR is merged

The `json` representation of the resource does come with the `version`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
