### PR TITLE
Enhance Users Resource with adapter-based info retrieval and filtering support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #78 Enhance Users Resource with adapter-based info retrieval and filtering support
 - #77 Include object version in JSON response
 - #76 Support multiple IInfo adapters per content type
 - #72 Fix logging issue for skipped fields with None-returning setters

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -793,6 +793,84 @@ update, but delegate the operation to the function `update_object` of this
 adapter.
 
 
+.. _USERS_FILTER:
+
+Filtering the users list
+------------------------
+
+The route `/users` can be extended to filter the returned users by providing
+one or more adapters for the `IUsersFilter` interface. These adapters are
+looked up against the current request and are only applied when listing users
+(`GET /users` without a specific username).
+
+Each adapter receives the current list of user ids and must return a (possibly)
+filtered list.
+
+Interface definition:
+
+.. code-block:: python
+
+    class IUsersFilter(interface.Interface):
+        """Interface to filter user listings for the users route"""
+
+        def filter(user_ids):
+            """Return a possibly filtered list of user ids"""
+
+Example: filter by role provided via querystring (e.g. `?role=LabManager`):
+
+.. code-block:: python
+
+    from senaite.jsonapi.interfaces import IUsersFilter
+    from senaite.jsonapi import api
+    from senaite.jsonapi import request as req
+    from zope import interface
+
+
+    class RoleFilterAdapter(object):
+        """Filters the users list by a given role.
+
+        Usage: GET /@@API/senaite/v1/users?role=LabManager
+        """
+        interface.implements(IUsersFilter)
+
+        def __init__(self, request):
+            self.request = request
+
+        def filter(self, user_ids):
+            # Only filter when a role was provided
+            role = req.get("role", None)
+            if not role:
+                return user_ids
+
+            filtered = []
+            for uid in user_ids:
+                user = api.get_user(uid)
+                if user and role in user.getRoles():
+                    filtered.append(uid)
+            return filtered
+
+Register the adapter for the request with ZCML:
+
+.. code-block:: xml
+
+    <configure xmlns="http://namespaces.zope.org/zope">
+
+      <!-- Adapter to filter users list via querystring -->
+      <adapter
+        for="zope.publisher.interfaces.browser.IBrowserRequest"
+        provides="senaite.jsonapi.interfaces.IUsersFilter"
+        factory=".adapters.RoleFilterAdapter" />
+
+    </configure>
+
+Notes:
+
+- Adapters should return the input list unchanged when their filter does not
+  apply, to keep composition predictable.
+- Filters are only applied on listings (`/users`), not when a specific
+  `username` is requested (e.g. `/users/<string:username>`).
+
+
 .. __PUSH:
 
 PUSH endpoint. Custom jobs

--- a/src/senaite/jsonapi/interfaces.py
+++ b/src/senaite/jsonapi/interfaces.py
@@ -178,3 +178,12 @@ class IPushConsumer(interface.Interface):
     def process(self):
         """Processes the job or raises an Exception if unable to succeed
         """
+
+
+class IUsersFilter(interface.Interface):
+    """Interface to filter user listings for the users route
+    """
+
+    def filter(user_ids):
+        """Return a possibly filtered list of user ids
+        """

--- a/src/senaite/jsonapi/tests/doctests/users.rst
+++ b/src/senaite/jsonapi/tests/doctests/users.rst
@@ -83,3 +83,82 @@ A single user can be retrieved too:
 
     >>> get("users/test_analyst_0")
     '..."username": "test_analyst_0"...'
+
+Extend user info via IInfo
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can enrich the user payload by registering an `IInfo` adapter for the
+Plone user. This adapter’s `to_dict` will be merged into each user item.
+
+Create and register a dummy `IInfo` adapter, following the pattern used in the
+push doctest:
+
+    >>> from senaite.jsonapi.interfaces import IInfo, IUsersFilter
+    >>> from zope.component import getGlobalSiteManager
+    >>> from zope.interface import implements
+    >>> from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
+    >>> from zope.publisher.interfaces.browser import IBrowserRequest
+    >>> from senaite.jsonapi import request as req
+
+    >>> class DummyUserInfoAdapter(object):
+    ...     """Adds a dummy flag to user info"""
+    ...     implements(IInfo)
+    ...     def __init__(self, context):
+    ...         self.context = context
+    ...     def to_dict(self):
+    ...         return {"dummy_info": True}
+
+    >>> sm = getGlobalSiteManager()
+    >>> sm.registerAdapter(DummyUserInfoAdapter, (IPropertiedUser,), IInfo)
+    >>> transaction.commit()
+
+The current user info now includes the additional data:
+
+    >>> response = get("users/current")
+    >>> data = json.loads(response)
+    >>> current = data.get("items")[0]
+    >>> current.get("dummy_info")
+    True
+
+Filter users via IUsersFilter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The users listing (`/users`) can be filtered by request-scoped adapters that
+implement `IUsersFilter`. Each adapter receives the current list of user ids
+and returns a possibly filtered list. This filter is only applied to listings
+and not when a specific username is requested.
+
+Create and register a dummy filter that narrows the list when the querystring
+contains `role=<rolename>`:
+
+    >>> from senaite.jsonapi import api
+    >>> class DummyUsersFilterAdapter(object):
+    ...     """Filters users by the 'role' query param"""
+    ...     implements(IUsersFilter)
+    ...     def __init__(self, request):
+    ...         self.request = request
+    ...
+    ...     def filter(self, user_ids):
+    ...         role = req.get("role", None)
+    ...         if not role:
+    ...             return user_ids
+    ...         filtered = []
+    ...         for uid in user_ids:
+    ...             user = api.get_user(uid)
+    ...             if user and role in user.getRoles():
+    ...                 filtered.append(uid)
+    ...         return filtered
+
+    >>> sm.registerAdapter(DummyUsersFilterAdapter, (IBrowserRequest,), IUsersFilter, name="dummy")
+    >>> transaction.commit()
+
+Requesting the users list with the filter applied returns only users with the
+requested role:
+
+    >>> response = get("users?role=Analyst")
+    >>> data = json.loads(response)
+    >>> items = data.get("items")
+    >>> len(items) > 0
+    True
+    >>> all(map(lambda it: u'Analyst' in it.get('roles', []), items))
+    True

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -67,7 +67,7 @@ def get_user_info(user):
             continue
         info[k] = v
 
-    for _, adapter in getAdapters((pu,), IInfo):
+    for name, adapter in getAdapters((pu,), IInfo):
         info.update(adapter.to_dict())
 
     return info
@@ -98,8 +98,9 @@ def get(context, request, username=None):
         user_ids = [username]
 
     # Allow addons to filter the user list via adapters
-    for _, adapter in getAdapters((request,), IUsersFilter):
-        user_ids = adapter.filter(user_ids) or user_ids
+    for name, adapter in getAdapters((request,), IUsersFilter):
+        if username is None:
+            user_ids = adapter.filter(user_ids)
 
     # Prepare batch
     size = req.get_batch_size()

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -24,6 +24,8 @@ from senaite.jsonapi import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import request as req
 from senaite.jsonapi.v1 import add_route
+from senaite.jsonapi.interfaces import IInfo
+from zope.component import getAdapters
 
 
 def get_user_info(user):
@@ -63,6 +65,9 @@ def get_user_info(user):
             logger.warn("User property '{}' is not JSON serializable".format(k))
             continue
         info[k] = v
+
+    for _, adapter in getAdapters((pu,), IInfo):
+        info.update(adapter.to_dict())
 
     return info
 

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -25,6 +25,7 @@ from senaite.jsonapi import logger
 from senaite.jsonapi import request as req
 from senaite.jsonapi.v1 import add_route
 from senaite.jsonapi.interfaces import IInfo
+from senaite.jsonapi.interfaces import IUsersFilter
 from zope.component import getAdapters
 
 
@@ -95,6 +96,10 @@ def get(context, request, username=None):
         user_ids = [current_user.getId()]
     else:
         user_ids = [username]
+
+    # Allow addons to filter the user list via adapters
+    for _, adapter in getAdapters((request,), IUsersFilter):
+        user_ids = adapter.filter(user_ids) or user_ids
 
     # Prepare batch
     size = req.get_batch_size()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR adds compatibility for `IInfo` adapters in user info retrieval, enabling custom extensions to dynamically enhance the user API response.
It also adds a new `IUsersFilter` interface to allow flexible and extensible user filtering during query operations.

## Current behavior before PR

- User data retrieval is limited to default fields without adapter-based extensions.
- Filtering logic cannot be customized or extended by other add-ons.

## Desired behavior after PR is merged

- User info can be extended through registered `IInfo` adapters.
- User queries can be dynamically filtered using `IUsersFilter` implementations, providing more control and modularity for custom add-ons.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
