### PR TITLE
Fix WrongType for UIDReferenceField

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #79 Fix WrongType for UIDReferenceField
 - #78 Enhance Users Resource with adapter-based info retrieval and filtering support
 - #77 Include object version in JSON response
 - #76 Support multiple IInfo adapters per content type

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -640,7 +640,7 @@ class UIDReferenceFieldMixin(object):
                                  "field {}".format(repr(self.field)))
 
         # convert all references to UIDs
-        refs = list(map(api.get_uid, refs))
+        refs = [str(api.get_uid(ref)) for ref in refs if ref]
 
         return self._set(instance, refs, **kw)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Fix `WrongType` errors when setting DX UIDReferenceField values via JSONAPI push, e.g. for `IClientShareableBehavior.clients`, by normalizing collected UIDs to native strings before field validation.

## Current behavior before PR
Creating or updating objects through JSONAPI `push` that include `UIDReferenceField` values (notably `IClientShareableBehavior.clients`) fails with an error similar to:
```
Cannot create object: TypeError - WrongType: Field=senaite.core.behaviors.clientshareable.IClientShareableBehavior.clients Value=[u'...']
```
because the underlying `List(ASCIILine)` receives a list of `Unicode` UIDs instead of native `str`, causing `WrongType/WrongContainedType` during validation.

## Desired behavior after PR is merged
UID reference field manager normalizes all collected references to native `str` UIDs before calling the field’s setter, so creating/updating objects with `UIDReferenceField` values (including clients) via JSONAPI succeeds and relations/backrefs are stored correctly, without raising `WrongType` errors.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
