### PR TITLE
Fix CI: use current branch and avoid True name in doctest globs

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,3 +1,10 @@
 [buildout]
 extends = https://raw.githubusercontent.com/senaite/senaite.core/2.x/buildout.base.cfg
 package-name = senaite.jsonapi
+auto-checkout =
+    senaite.core
+    senaite.app.listing
+    senaite.app.spotlight
+    senaite.app.supermodel
+    senaite.impress
+    senaite.lims

--- a/src/senaite/jsonapi/tests/doctests/users.rst
+++ b/src/senaite/jsonapi/tests/doctests/users.rst
@@ -106,7 +106,7 @@ push doctest:
     ...     def __init__(self, context):
     ...         self.context = context
     ...     def to_dict(self):
-    ...         return {"dummy_info": True}
+    ...         return {"dummy_info": (1 == 1)}
 
     >>> sm = getGlobalSiteManager()
     >>> sm.registerAdapter(DummyUserInfoAdapter, (IPropertiedUser,), IInfo)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes two issues:

1. buildout.base.cfg has auto-checkout=* which caused mr.developer to checkout senaite.jsonapi from branch=2.x to src/senaite.jsonapi/, overriding the current branch checkout in '.'. Override auto-checkout to list all packages except senaite.jsonapi so that develop=. picks up the correct branch.

2. DummyUserInfoAdapter.to_dict uses 'True' by name. The doctest framework clears the globs dict after users.rst finishes, but the adapter stays registered in the global site manager. When auth.rst triggers a login, to_dict.__globals__ points to the cleared dict where True is no longer defined. Use (1 == 1) instead.


## Current behavior before PR

Tests fail

## Desired behavior after PR is merged

Tests pass

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
