### PR TITLE
Add Bearer token (JWT) authentication via PAS plugin

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -7,27 +7,27 @@ The API provides a simple way to authenticate a user with SENAITE.
 Login
 -----
 
-:URL Schema: ``<BASE URL>/login?__ac_name=<username>&__ac_password=<password>``
+:URL Schema: `<BASE URL>/login?__ac_name=<username>&__ac_password=<password>`
 
-The response sets the ``__ac`` cookie for further cookie-authenticated
+The response sets the `__ac` cookie for further cookie-authenticated
 requests. In addition, a JSON Web Token (JWT) is returned in the
-response body as ``token`` (with the Unix expiration timestamp as
-``expires``) and is also set as the HttpOnly ``token`` cookie.
+response body as `token` (with the Unix expiration timestamp as
+`expires`) and is also set as the HttpOnly `token` cookie.
 Subsequent requests can be authenticated with either the cookie or by
-sending the token in the ``Authorization: Bearer <token>`` header (see
-``Bearer Token Authentication`` below).
+sending the token in the `Authorization: Bearer <token>` header (see
+`Bearer Token Authentication` below).
 
 The route accepts two authentication modes:
 
-1. **HTTP Basic auth** (``Authorization: Basic ...`` header). No body
+1. **HTTP Basic auth** (`Authorization: Basic ...` header). No body
    fields are needed; the route issues a token for the user that was
    already authenticated by the PAS layer.
-2. **Form login** with ``__ac_name`` and ``__ac_password`` as form
+2. **Form login** with `__ac_name` and `__ac_password` as form
    fields, as shown in the example below.
 
 Example
 
-``http://localhost:8080/senaite/@@API/senaite/v1/login?__ac_name=admin&__ac_password=admin``
+`http://localhost:8080/senaite/@@API/senaite/v1/login?__ac_name=admin&__ac_password=admin`
 
 Response
 
@@ -62,19 +62,19 @@ Response
 Logout
 ------
 
-:URL Schema: ``<BASE URL>/users/logout``
+:URL Schema: `<BASE URL>/users/logout`
 
-The response expires the ``__ac`` and ``token`` cookies on the client.
+The response expires the `__ac` and `token` cookies on the client.
 Note that this does not invalidate the JWT itself: a token that was
 already extracted from the response and stored by the client remains
-valid until its ``exp`` claim is reached. To revoke a token
+valid until its `exp` claim is reached. To revoke a token
 server-side before it expires, rotate the user's signing secret with
-``senaite.jsonapi.pas.plugin.rotate_secret(userid)``; this invalidates
+`senaite.jsonapi.pas.plugin.rotate_secret(userid)`; this invalidates
 every token previously issued for that user.
 
 Example
 
-``http://localhost:8080/senaite/@@API/senaite/v1/users/logout``
+`http://localhost:8080/senaite/@@API/senaite/v1/users/logout`
 
 Response
 
@@ -90,7 +90,7 @@ Response
 Basic Authentication
 --------------------
 
-:URL Schema: ``<BASE URL>/auth``
+:URL Schema: `<BASE URL>/auth`
 
 If the request is not authenticated, this route will raise an unauthorized
 response with status code 401. Browsers should display the Basic Authentication
@@ -98,15 +98,15 @@ login.
 
 Example
 
-``http://localhost:8080/senaite/@@API/senaite/v1/auth``
+`http://localhost:8080/senaite/@@API/senaite/v1/auth`
 
 
 Bearer Token Authentication
 ---------------------------
 
-After a successful ``/login`` call, the JWT returned in the response
+After a successful `/login` call, the JWT returned in the response
 body can be used to authenticate any subsequent request by sending it
-in the standard ``Authorization`` header:
+in the standard `Authorization` header:
 
 .. code-block:: text
 
@@ -114,14 +114,14 @@ in the standard ``Authorization`` header:
 
 The token is extracted, in this order, from:
 
-1. ``Authorization: Bearer <token>`` header
-2. ``token`` cookie (HttpOnly, set automatically by ``/login``)
-3. ``X-JWT-Auth-Token`` header (fallback for clients that cannot set
-   the ``Authorization`` header)
+1. `Authorization: Bearer <token>` header
+2. `token` cookie (HttpOnly, set automatically by `/login`)
+3. `X-JWT-Auth-Token` header (fallback for clients that cannot set
+   the `Authorization` header)
 
 Tokens are signed per user with a secret generated on first use and
 stored in the portal's annotations. The default token lifetime is
-60 minutes (``JWT_TOKENS_TIMEOUT`` in ``senaite.jsonapi.config``).
+60 minutes (`JWT_TOKENS_TIMEOUT` in `senaite.jsonapi.config`).
 
 Example
 
@@ -134,7 +134,7 @@ Example
 Revoking tokens
 ~~~~~~~~~~~~~~~
 
-JWTs are stateless: ``/logout`` only expires the client-side cookie. To
+JWTs are stateless: `/logout` only expires the client-side cookie. To
 revoke every token issued for a given user, rotate their signing
 secret from a debug shell or upgrade step:
 
@@ -143,7 +143,7 @@ secret from a debug shell or upgrade step:
     from senaite.jsonapi.pas.plugin import rotate_secret
     rotate_secret("johndoe")
 
-The next call to ``/login`` for that user generates a new secret and
+The next call to `/login` for that user generates a new secret and
 issues a new token; all previously-issued tokens fail signature
 verification.
 
@@ -151,11 +151,11 @@ verification.
 Cookie security
 ~~~~~~~~~~~~~~~
 
-The ``token`` cookie is set with ``HttpOnly``, ``Secure`` and
-``SameSite=Lax``. The ``Secure`` flag means the cookie is only sent
+The `token` cookie is set with `HttpOnly`, `Secure` and
+`SameSite=Lax`. The `Secure` flag means the cookie is only sent
 over HTTPS; on plain HTTP setups (local development, non-TLS
 deployments) the cookie will not round-trip and clients must use the
-``Authorization: Bearer`` header instead.
+`Authorization: Bearer` header instead.
 
 
 Try it
@@ -182,9 +182,9 @@ session, then open the DevTools console and run:
     })
     console.log(await me.json())
 
-Over plain ``http://`` the ``Secure`` ``token`` cookie is not retained
+Over plain `http://` the `Secure` `token` cookie is not retained
 by the browser, but the JSON body still carries the token — use the
-``Authorization: Bearer`` header.
+`Authorization: Bearer` header.
 
 
 curl
@@ -220,17 +220,17 @@ Verify the expected failures:
 Test the Secure cookie path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``Secure`` flag requires HTTPS. Easiest local option is to put a
+The `Secure` flag requires HTTPS. Easiest local option is to put a
 reverse proxy in front of the Zope instance, for example with Caddy:
 
 .. code-block:: bash
 
     caddy reverse-proxy --from https://localhost:8443 --to localhost:8080
 
-After ``/login``, open DevTools → Application → Cookies →
-``https://localhost:8443`` and verify the ``token`` cookie is set
-with ``HttpOnly``, ``Secure`` and ``SameSite=Lax``. Subsequent
-``fetch`` calls without the ``Authorization`` header are authenticated
+After `/login`, open DevTools → Application → Cookies →
+`https://localhost:8443` and verify the `token` cookie is set
+with `HttpOnly`, `Secure` and `SameSite=Lax`. Subsequent
+`fetch` calls without the `Authorization` header are authenticated
 by the cookie automatically.
 
 
@@ -257,8 +257,8 @@ old token to confirm it is rejected:
 REST client (Bruno, Insomnia, Postman)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Define a collection-level variable ``token`` and populate it from the
-``/login`` response (most clients support extracting a JSON field into
+Define a collection-level variable `token` and populate it from the
+`/login` response (most clients support extracting a JSON field into
 an environment variable). Add the header
-``Authorization: Bearer {{token}}`` at the collection level so every
+`Authorization: Bearer {{token}}` at the collection level so every
 request in the collection authenticates transparently.

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -156,3 +156,109 @@ The ``token`` cookie is set with ``HttpOnly``, ``Secure`` and
 over HTTPS; on plain HTTP setups (local development, non-TLS
 deployments) the cookie will not round-trip and clients must use the
 ``Authorization: Bearer`` header instead.
+
+
+Try it
+------
+
+DevTools console (fastest)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Log into SENAITE via the standard UI so the browser has a Plone
+session, then open the DevTools console and run:
+
+.. code-block:: javascript
+
+    // /login is cookie-authenticated by the existing session and
+    // returns a fresh JWT in the body
+    const r = await fetch("/senaite/@@API/senaite/v1/login",
+                         {credentials: "include"})
+    const {token} = await r.json()
+    console.log(token)
+
+    // Use the token to authenticate any subsequent request
+    const me = await fetch("/senaite/@@API/senaite/v1/users/current", {
+      headers: {Authorization: `Bearer ${token}`}
+    })
+    console.log(await me.json())
+
+Over plain ``http://`` the ``Secure`` ``token`` cookie is not retained
+by the browser, but the JSON body still carries the token — use the
+``Authorization: Bearer`` header.
+
+
+curl
+~~~~
+
+.. code-block:: bash
+
+    # Form login
+    TOKEN=$(curl -s -X POST \
+        http://localhost:8080/senaite/@@API/senaite/v1/login \
+        -d "__ac_name=admin&__ac_password=admin" | jq -r .token)
+
+    # Or Basic auth
+    TOKEN=$(curl -s -u admin:admin \
+        http://localhost:8080/senaite/@@API/senaite/v1/login | jq -r .token)
+
+    # Use it
+    curl -H "Authorization: Bearer $TOKEN" \
+        http://localhost:8080/senaite/@@API/senaite/v1/users/current
+
+Verify the expected failures:
+
+.. code-block:: bash
+
+    # Bogus token -> 401
+    curl -i -H "Authorization: Bearer not-a-real-token" \
+        http://localhost:8080/senaite/@@API/senaite/v1/auth
+
+    # No token -> 401
+    curl -i http://localhost:8080/senaite/@@API/senaite/v1/auth
+
+
+Test the Secure cookie path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``Secure`` flag requires HTTPS. Easiest local option is to put a
+reverse proxy in front of the Zope instance, for example with Caddy:
+
+.. code-block:: bash
+
+    caddy reverse-proxy --from https://localhost:8443 --to localhost:8080
+
+After ``/login``, open DevTools → Application → Cookies →
+``https://localhost:8443`` and verify the ``token`` cookie is set
+with ``HttpOnly``, ``Secure`` and ``SameSite=Lax``. Subsequent
+``fetch`` calls without the ``Authorization`` header are authenticated
+by the cookie automatically.
+
+
+Revocation
+~~~~~~~~~~
+
+Rotate the user's signing secret from a debug shell, then reuse the
+old token to confirm it is rejected:
+
+.. code-block:: python
+
+    bin/instance debug
+    >>> from senaite.jsonapi.pas.plugin import rotate_secret
+    >>> rotate_secret("admin")
+    >>> import transaction; transaction.commit()
+
+.. code-block:: bash
+
+    # Previously valid token -> 401
+    curl -i -H "Authorization: Bearer $TOKEN" \
+        http://localhost:8080/senaite/@@API/senaite/v1/auth
+
+
+REST client (Bruno, Insomnia, Postman)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Define a collection-level variable ``token`` and populate it from the
+``/login`` response (most clients support extracting a JSON field into
+an environment variable). Add the header
+``Authorization: Bearer {{token}}`` at the collection level so every
+request in the collection authenticates transparently.

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -9,10 +9,21 @@ Login
 
 :URL Schema: ``<BASE URL>/login?__ac_name=<username>&__ac_password=<password>``
 
-The response will set the `__ac` cookie for further cookie authenticated requests.
+The response sets the ``__ac`` cookie for further cookie-authenticated
+requests. In addition, a JSON Web Token (JWT) is returned in the
+response body as ``token`` (with the Unix expiration timestamp as
+``expires``) and is also set as the HttpOnly ``token`` cookie.
+Subsequent requests can be authenticated with either the cookie or by
+sending the token in the ``Authorization: Bearer <token>`` header (see
+``Bearer Token Authentication`` below).
 
-.. note:: Currently only cookie authentication works. Other PAS plugins might
-          not work as expected.
+The route accepts two authentication modes:
+
+1. **HTTP Basic auth** (``Authorization: Basic ...`` header). No body
+   fields are needed; the route issues a token for the user that was
+   already authenticated by the PAS layer.
+2. **Form login** with ``__ac_name`` and ``__ac_password`` as form
+   fields, as shown in the example below.
 
 Example
 
@@ -25,6 +36,8 @@ Response
     {
         url: "http://localhost:8080/senaite/@@API/senaite/v1/users",
         count: 1,
+        token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+        expires: 1735689600,
         _runtime: 0.0019960403442382812,
         items: [
             {
@@ -51,7 +64,13 @@ Logout
 
 :URL Schema: ``<BASE URL>/users/logout``
 
-The response will expire the `__ac` cookie for further requests.
+The response expires the ``__ac`` and ``token`` cookies on the client.
+Note that this does not invalidate the JWT itself: a token that was
+already extracted from the response and stored by the client remains
+valid until its ``exp`` claim is reached. To revoke a token
+server-side before it expires, rotate the user's signing secret with
+``senaite.jsonapi.pas.plugin.rotate_secret(userid)``; this invalidates
+every token previously issued for that user.
 
 Example
 
@@ -80,3 +99,60 @@ login.
 Example
 
 ``http://localhost:8080/senaite/@@API/senaite/v1/auth``
+
+
+Bearer Token Authentication
+---------------------------
+
+After a successful ``/login`` call, the JWT returned in the response
+body can be used to authenticate any subsequent request by sending it
+in the standard ``Authorization`` header:
+
+.. code-block:: text
+
+    Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
+
+The token is extracted, in this order, from:
+
+1. ``Authorization: Bearer <token>`` header
+2. ``token`` cookie (HttpOnly, set automatically by ``/login``)
+3. ``X-JWT-Auth-Token`` header (fallback for clients that cannot set
+   the ``Authorization`` header)
+
+Tokens are signed per user with a secret generated on first use and
+stored in the portal's annotations. The default token lifetime is
+60 minutes (``JWT_TOKENS_TIMEOUT`` in ``senaite.jsonapi.config``).
+
+Example
+
+.. code-block:: bash
+
+    curl -H "Authorization: Bearer $TOKEN" \
+        http://localhost:8080/senaite/@@API/senaite/v1/users/current
+
+
+Revoking tokens
+~~~~~~~~~~~~~~~
+
+JWTs are stateless: ``/logout`` only expires the client-side cookie. To
+revoke every token issued for a given user, rotate their signing
+secret from a debug shell or upgrade step:
+
+.. code-block:: python
+
+    from senaite.jsonapi.pas.plugin import rotate_secret
+    rotate_secret("johndoe")
+
+The next call to ``/login`` for that user generates a new secret and
+issues a new token; all previously-issued tokens fail signature
+verification.
+
+
+Cookie security
+~~~~~~~~~~~~~~~
+
+The ``token`` cookie is set with ``HttpOnly``, ``Secure`` and
+``SameSite=Lax``. The ``Secure`` flag means the cookie is only sent
+over HTTPS; on plain HTTP setups (local development, non-TLS
+deployments) the cookie will not round-trip and clients must use the
+``Authorization: Bearer`` header instead.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,9 +8,12 @@ Changelog
 
    This release introduces the first GenericSetup profile for
    senaite.jsonapi. Existing sites upgrading from 2.6.x must install
-   the add-on once from `Site Setup` -> `Add-ons` (or apply the
-   `senaite.jsonapi:default` profile) to enable JWT authentication;
-   the cookie/Basic auth paths keep working without the install.
+   the add-on once: go to `Site Setup` -> `Add-ons`, find
+   *SENAITE JSONAPI* in the "Available add-ons" list, and click
+   *Install*. The cookie and Basic auth paths keep working without
+   the install; only the JWT authentication path needs the profile
+   applied. Uninstalling from the same panel removes the PAS plugin
+   and the per-user JWT signing secrets.
 
 - #88 Add Bearer token (JWT) authentication via PAS plugin
 - #87 Inject additional analyses fields

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+.. note::
+
+   This release introduces the first GenericSetup profile for
+   senaite.jsonapi. Existing sites upgrading from 2.6.x must install
+   the add-on once from `Site Setup` -> `Add-ons` (or apply the
+   `senaite.jsonapi:default` profile) to enable JWT authentication;
+   the cookie/Basic auth paths keep working without the install.
+
 - #88 Add Bearer token (JWT) authentication via PAS plugin
 - #87 Inject additional analyses fields
 - #85 Allow field projection

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #88 Add Bearer token (JWT) authentication via PAS plugin
 - #87 Inject additional analyses fields
 - #85 Allow field projection
 - #81 Support second-level precision on searches against DateIndex

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
     install_requires=[
         "setuptools",
         "senaite.core",
+        # PyJWT >=2.0.0 does not support Python 2.x anymore
+        "pyjwt<2.0.0",
     ],
     extras_require={
         "test": [

--- a/src/senaite/jsonapi/config.py
+++ b/src/senaite/jsonapi/config.py
@@ -17,3 +17,19 @@
 #
 # Copyright 2017-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
+from senaite.jsonapi import PRODUCT_NAME
+
+# Default JWT lifetime (60 minutes, in seconds)
+JWT_TOKENS_TIMEOUT = 60 * 60
+
+# Name of the HttpOnly cookie used to carry the JWT token
+JWT_COOKIE_ID = "token"
+
+# Fallback header used to carry the JWT token when neither the
+# Authorization Bearer header nor the cookie is set
+JWT_HEADER_ID = "X-JWT-Auth-Token"
+
+# Annotation key used to store the per-user JWT signing secrets on the
+# portal (IAnnotations(portal)[KEY_STORAGE] is an OOBTree keyed by userid)
+KEY_STORAGE = "%s.pas.keystorage" % PRODUCT_NAME

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -26,6 +26,24 @@
     <depends name="plone-various"/>
   </genericsetup:importStep>
 
+  <!-- Uninstall profile -->
+  <genericsetup:registerProfile
+      name="uninstall"
+      title="SENAITE JSONAPI (Uninstall)"
+      description="Removes SENAITE JSONAPI's JWT PAS plugin and key storage"
+      directory="profiles/uninstall"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <!-- Uninstall import step -->
+  <genericsetup:importStep
+      name="senaite.jsonapi.uninstallhandler"
+      title="senaite.jsonapi uninstall handler"
+      description="Removes SENAITE JSONAPI's JWT PAS plugin and key storage"
+      handler="senaite.jsonapi.setuphandlers.uninstall_handler">
+    <depends name="plone-various"/>
+  </genericsetup:importStep>
+
   <!-- CATALOG
        Unified interface to one or more Portal Catalog tools.
   -->

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -17,6 +17,12 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <!-- Hide the uninstall profile from the Add-ons control panel -->
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      name="senaite.jsonapi"
+      />
+
   <!-- Setup import step -->
   <genericsetup:importStep
       name="senaite.jsonapi.setuphandler"

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -1,11 +1,30 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="senaite.jsonapi">
 
   <!-- Package Includes -->
   <include package=".v1"/>
+
+  <!-- GenericSetup profile -->
+  <genericsetup:registerProfile
+      name="default"
+      title="SENAITE JSONAPI"
+      description="Installs SENAITE JSONAPI's JWT PAS plugin"
+      directory="profiles/default"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <!-- Setup import step -->
+  <genericsetup:importStep
+      name="senaite.jsonapi.setuphandler"
+      title="senaite.jsonapi setup handler"
+      description="Installs SENAITE JSONAPI's JWT PAS Pugin"
+      handler="senaite.jsonapi.setuphandlers.setup_handler">
+    <depends name="plone-various"/>
+  </genericsetup:importStep>
 
   <!-- CATALOG
        Unified interface to one or more Portal Catalog tools.

--- a/src/senaite/jsonapi/pas/__init__.py
+++ b/src/senaite/jsonapi/pas/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2026 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/jsonapi/pas/plugin.py
+++ b/src/senaite/jsonapi/pas/plugin.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2026 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from calendar import timegm
+from datetime import timedelta
+
+import jwt
+from AccessControl import ClassSecurityInfo
+from bika.lims import api
+from BTrees.OOBTree import OOBTree
+from plone.keyring.keyring import GenerateSecret
+from Products.PluggableAuthService.interfaces import plugins
+from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
+from senaite.core.api import dtime
+from senaite.jsonapi import PRODUCT_NAME
+from senaite.jsonapi.config import JWT_COOKIE_ID
+from senaite.jsonapi.config import JWT_HEADER_ID
+from senaite.jsonapi.config import JWT_TOKENS_TIMEOUT
+from senaite.jsonapi.config import KEY_STORAGE
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import implementer
+
+# The id of the plugin
+ID = "%s.pas.plugin.JWTAuthenticationPlugin" % PRODUCT_NAME
+
+# Meta type name of the plugin
+META_TYPE = "%s: JWT Authentication Plugin" % PRODUCT_NAME
+
+
+@implementer(plugins.IAuthenticationPlugin, plugins.IExtractionPlugin)
+class JWTAuthenticationPlugin(BasePlugin):
+    """PAS plugin for authentication with JSON Web tokens (JWT).
+
+    JWT authentication is a stateless, token-based method where the SENAITE
+    server issues a signed token to a client after a user logs in. The client
+    then stores this token and includes it in subsequent requests to access
+    protected resources, allowing the server to verify the user's identity
+    without needing to store session data on the server-side.
+    """
+
+    id = ID
+    title = META_TYPE
+    meta_type = META_TYPE
+    security = ClassSecurityInfo()
+
+    @security.private
+    def extractCredentials(self, request):  # noqa camelCase
+        """IExtractionPlugin implementation. Extracts the JSON Web Token (JWT)
+        from the request, if any. Returns a dict made of {"token": <token>}
+        :param request: the HTTPRequest object to extract credentials from
+        :return: a dict with credentials
+        """
+        token = get_jwt_token(request)
+        if not token:
+            return {}
+        return {"token": token}
+
+    @security.private
+    def authenticateCredentials(self, credentials):  # noqa camelCase
+        """IAuthenticationPlugin implementation, maps credentials to a User ID.
+        If credentials cannot be authenticated, return None
+        :param credentials: dict with credentials
+        :return: a tuple with the user id and login name or None
+        """
+        # Ignore credentials that are not from our extractor
+        extractor = credentials.get("extractor")
+        if extractor != self.getId():
+            return None
+
+        token = credentials.get("token")
+        if not token:
+            return None
+
+        # Peek the payload (no signature check) to learn the userid the
+        # token claims to belong to
+        userid = peek_userid(token)
+        if not userid:
+            return None
+
+        # Verify signature and expiration with that user's secret
+        payload = decode_token(token, userid)
+        if not payload:
+            return None
+
+        # Defensive: ensure the verified payload still names the same user
+        if api.to_utf8(payload.get("userid"), default=None) != userid:
+            return None
+
+        # Make sure the user still exists
+        user = api.get_user(userid)
+        if not user:
+            return None
+
+        return userid, userid
+
+
+def get_jwt_token(request):
+    """Extracts the JWT token from the request, in this order of preference:
+    Authorization: Bearer header, "token" cookie, X-JWT-Auth-Token header.
+    """
+    # Read from Authorization header
+    auth = request._auth  # noqa
+    if auth and auth[:7].lower() == "bearer ":
+        return auth.split()[-1]
+
+    # Read from cookie
+    token = request.cookies.get(JWT_COOKIE_ID)
+    if token:
+        return token
+
+    # Read from header
+    return request.getHeader(JWT_HEADER_ID)
+
+
+def get_keystorage():
+    """Returns the OOBTree where per-user JWT signing secrets are stored,
+    creating it lazily on the portal's annotations on first access.
+    """
+    annotation = IAnnotations(api.get_portal())
+    storage = annotation.get(KEY_STORAGE)
+    if storage is None:
+        annotation[KEY_STORAGE] = OOBTree()
+    return annotation[KEY_STORAGE]
+
+
+def signing_secret(userid):
+    """Returns the signing secret for the given userid, generating one
+    on first call.
+    """
+    userid = api.to_utf8(userid, default=None)
+    if not userid:
+        raise ValueError("Invalid userid: %r" % userid)
+
+    storage = get_keystorage()
+    data = storage.get(userid)
+    if not data:
+        storage[userid] = {
+            "key": GenerateSecret(),
+            "created": timestamp(),
+        }
+    return storage[userid]["key"]
+
+
+def rotate_secret(userid):
+    """Discards the signing secret for the given userid, so a new one is
+    generated on the next call to ``signing_secret``. All previously
+    issued tokens for the user are invalidated.
+    """
+    userid = api.to_utf8(userid, default=None)
+    if not userid:
+        return
+    storage = get_keystorage()
+    if userid in storage:
+        del storage[userid]
+
+
+def timestamp(seconds=0, minutes=0, hours=0, days=0):
+    """Returns a Unix timestamp from GMT plus the given offset.
+    """
+    delta = timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
+    utc = dtime.datetime.utcnow() + delta
+    return timegm(utc.utctimetuple())
+
+
+def peek_userid(token):
+    """Returns the ``userid`` claim of the given token without verifying
+    the signature, or None if the token cannot be decoded.
+    """
+    token = api.to_utf8(token, default=None)
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, verify=False)
+    except (ValueError, TypeError, jwt.InvalidTokenError):
+        return None
+    return api.to_utf8(payload.get("userid"), default=None)
+
+
+def decode_token(token, userid):
+    """Decodes the given JWT, verifies the signature with ``userid``'s
+    secret and checks the expiration. Returns the payload or None.
+    """
+    token = api.to_utf8(token, default=None)
+    if not token:
+        return None
+    try:
+        secret = signing_secret(userid)
+        return jwt.decode(token, secret, algorithms=["HS256"])
+    except (ValueError, TypeError, jwt.InvalidTokenError):
+        return None
+
+
+def create_token(userid, timeout=JWT_TOKENS_TIMEOUT, **kwargs):
+    """Creates a JSON Web Token (JWT) for the given userid.
+    """
+    payload = {
+        "userid": userid,
+        "exp": timestamp(seconds=timeout),
+    }
+    payload.update(kwargs)
+
+    secret = signing_secret(userid)
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    return api.safe_unicode(token)

--- a/src/senaite/jsonapi/pas/plugin.py
+++ b/src/senaite/jsonapi/pas/plugin.py
@@ -182,6 +182,14 @@ def timestamp(seconds=0, minutes=0, hours=0, days=0):
 def peek_userid(token):
     """Returns the ``userid`` claim of the given token without verifying
     the signature, or None if the token cannot be decoded.
+
+    Decoding the token without verifying its signature is safe in this
+    context: the returned ``userid`` is only used to look up *that
+    user's* signing secret, which is then used to verify the signature
+    in ``decode_token``. A forged token that claims to belong to user
+    X but was signed with anything other than X's real secret fails
+    signature verification and is rejected. The unverified ``userid``
+    is never trusted on its own.
     """
     token = api.to_utf8(token, default=None)
     if not token:

--- a/src/senaite/jsonapi/profiles/default/metadata.xml
+++ b/src/senaite/jsonapi/profiles/default/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+</metadata>

--- a/src/senaite/jsonapi/profiles/default/metadata.xml
+++ b/src/senaite/jsonapi/profiles/default/metadata.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
   <version>1</version>
+  <dependencies>
+    <dependency>profile-senaite.core:default</dependency>
+  </dependencies>
 </metadata>

--- a/src/senaite/jsonapi/profiles/default/senaite.jsonapi.txt
+++ b/src/senaite/jsonapi/profiles/default/senaite.jsonapi.txt
@@ -1,0 +1,1 @@
+Marker file checked by senaite.jsonapi.setuphandlers.setup_handler

--- a/src/senaite/jsonapi/profiles/uninstall/metadata.xml
+++ b/src/senaite/jsonapi/profiles/uninstall/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+</metadata>

--- a/src/senaite/jsonapi/profiles/uninstall/senaite.jsonapi-uninstall.txt
+++ b/src/senaite/jsonapi/profiles/uninstall/senaite.jsonapi-uninstall.txt
@@ -1,0 +1,1 @@
+Marker file checked by senaite.jsonapi.setuphandlers.uninstall_handler

--- a/src/senaite/jsonapi/setuphandlers.py
+++ b/src/senaite/jsonapi/setuphandlers.py
@@ -18,10 +18,14 @@
 # Copyright 2017-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from senaite.jsonapi import logger
 from senaite.jsonapi import PRODUCT_NAME
+from senaite.jsonapi.config import KEY_STORAGE
+from senaite.jsonapi.pas.plugin import ID as JWT_PLUGIN_ID
 from senaite.jsonapi.pas.plugin import JWTAuthenticationPlugin
+from zope.annotation.interfaces import IAnnotations
 
 
 def setup_handler(context):
@@ -65,3 +69,38 @@ def setup_pas_plugin(portal):
             plugin_registry.movePluginsTop(iface, [plugin_id])
 
     logger.info("Setup %s plugin [DONE]" % plugin_id)
+
+
+def uninstall_handler(context):
+    """Generic setup uninstall handler for senaite.jsonapi
+    """
+    uninstall_file = "%s-uninstall.txt" % PRODUCT_NAME
+    if context.readDataFile(uninstall_file) is None:
+        return
+
+    logger.info("%s uninstall handler [BEGIN]" % PRODUCT_NAME.upper())
+    portal = context.getSite()
+
+    remove_pas_plugin(portal)
+    remove_keystorage(portal)
+
+    logger.info("%s uninstall handler [DONE]" % PRODUCT_NAME.upper())
+
+
+def remove_pas_plugin(portal):
+    """Remove the JWT PAS plugin from the site's acl_users.
+    """
+    pas = portal.acl_users
+    if JWT_PLUGIN_ID in pas.objectIds():
+        logger.info("Remove %s plugin ..." % JWT_PLUGIN_ID)
+        pas.manage_delObjects([JWT_PLUGIN_ID])
+
+
+def remove_keystorage(portal):
+    """Drop the per-user JWT signing secrets from the portal's
+    annotations. All previously-issued tokens become unverifiable.
+    """
+    annotation = IAnnotations(api.get_portal())
+    if KEY_STORAGE in annotation:
+        logger.info("Remove %s key storage ..." % PRODUCT_NAME)
+        del annotation[KEY_STORAGE]

--- a/src/senaite/jsonapi/setuphandlers.py
+++ b/src/senaite/jsonapi/setuphandlers.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from Products.CMFPlone.interfaces import INonInstallable
 from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from senaite.jsonapi import logger
 from senaite.jsonapi import PRODUCT_NAME
@@ -26,6 +27,24 @@ from senaite.jsonapi.config import KEY_STORAGE
 from senaite.jsonapi.pas.plugin import ID as JWT_PLUGIN_ID
 from senaite.jsonapi.pas.plugin import JWTAuthenticationPlugin
 from zope.annotation.interfaces import IAnnotations
+from zope.interface import implementer
+
+
+@implementer(INonInstallable)
+class HiddenProfiles(object):
+    """Hide the uninstall profile from the Add-ons control panel so it
+    is not listed as an installable add-on. The Add-ons panel only
+    shows the `default` profile; the `uninstall` profile is applied
+    automatically when the user clicks "Uninstall".
+    """
+
+    def getNonInstallableProfiles(self):  # noqa camelCase
+        return [
+            "%s:uninstall" % PRODUCT_NAME,
+        ]
+
+    def getNonInstallableProducts(self):  # noqa camelCase
+        return []
 
 
 def setup_handler(context):

--- a/src/senaite/jsonapi/setuphandlers.py
+++ b/src/senaite/jsonapi/setuphandlers.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from Products.PlonePAS.setuphandlers import activatePluginInterfaces
+from senaite.jsonapi import logger
+from senaite.jsonapi import PRODUCT_NAME
+from senaite.jsonapi.pas.plugin import JWTAuthenticationPlugin
+
+
+def setup_handler(context):
+    """Generic setup handler for senaite.jsonapi
+    """
+    install_file = "%s.txt" % PRODUCT_NAME
+    if context.readDataFile(install_file) is None:
+        return
+
+    logger.info("%s setup handler [BEGIN]" % PRODUCT_NAME.upper())
+    portal = context.getSite()
+
+    setup_pas_plugin(portal)
+
+    logger.info("%s setup handler [DONE]" % PRODUCT_NAME.upper())
+
+
+def setup_pas_plugin(portal):
+    """Register the JWT PAS plugin in the site's acl_users so JWT-based
+    authentication becomes active.
+    """
+    plugin = JWTAuthenticationPlugin()
+    plugin_id = plugin.getId()
+
+    logger.info("Setup %s plugin ..." % plugin_id)
+
+    pas = portal.acl_users
+    if plugin_id not in pas.objectIds():
+        # Add the plugin
+        pas._setObject(plugin_id, plugin)  # noqa
+
+        # Activate all supported interfaces for this plugin
+        activatePluginInterfaces(pas, plugin_id)
+
+        # Make our plugin the first one for these interfaces, so the JWT
+        # token takes precedence over other extractors/authenticators
+        ifaces = ["IExtractionPlugin", "IAuthenticationPlugin"]
+        plugin_registry = pas.plugins
+        for iface_name in ifaces:
+            iface = plugin_registry._getInterfaceFromName(iface_name)  # noqa
+            plugin_registry.movePluginsTop(iface, [plugin_id])
+
+    logger.info("Setup %s plugin [DONE]" % plugin_id)

--- a/src/senaite/jsonapi/tests/base.py
+++ b/src/senaite/jsonapi/tests/base.py
@@ -78,6 +78,9 @@ class SimpleTestLayer(PloneSandboxLayer):
         # Apply Setup Profile (portal_quickinstaller)
         applyProfile(portal, "senaite.core:default")
 
+        # Install the JWT PAS plugin
+        applyProfile(portal, "senaite.jsonapi:default")
+
         # Add test users
         self.add_test_users(portal)
 

--- a/src/senaite/jsonapi/tests/doctests/bearer.rst
+++ b/src/senaite/jsonapi/tests/doctests/bearer.rst
@@ -74,6 +74,19 @@ header is authenticated by the JWT PAS plugin:
     True
 
 
+The X-JWT-Auth-Token fallback header authenticates the request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Clients that cannot set the ``Authorization`` header (some embedded
+HTTP libraries, browser extensions, etc.) can use the
+``X-JWT-Auth-Token`` fallback header instead:
+
+    >>> fallback = fresh_browser()
+    >>> fallback.addHeader("X-JWT-Auth-Token", token)
+    >>> is_authenticated(fallback)
+    True
+
+
 An invalid Bearer token does not authenticate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/senaite/jsonapi/tests/doctests/bearer.rst
+++ b/src/senaite/jsonapi/tests/doctests/bearer.rst
@@ -1,0 +1,127 @@
+BEARER TOKEN AUTHENTICATION
+---------------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t bearer
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.testing.zope import Browser
+    >>> from senaite.jsonapi.pas.plugin import create_token
+    >>> from senaite.jsonapi.pas.plugin import rotate_secret
+    >>> from senaite.jsonapi.pas.plugin import timestamp
+
+
+Functional Helpers:
+
+    >>> def fresh_browser():
+    ...     b = Browser(self.portal)
+    ...     b.addHeader("Accept-Language", "en-US")
+    ...     b.handleErrors = False
+    ...     return b
+
+    >>> def with_bearer(b, token):
+    ...     b.addHeader("Authorization", "Bearer {}".format(token))
+    ...     return b
+
+    >>> def is_authenticated(b):
+    ...     b.open("{}/users/current".format(api_url))
+    ...     return json.loads(b.contents)["items"][0]["authenticated"]
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> portal_url = portal.absolute_url()
+    >>> api_url = "{}/@@API/senaite/v1".format(portal_url)
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+
+No token, no authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A fresh browser without any credentials is anonymous:
+
+    >>> is_authenticated(fresh_browser())
+    False
+
+
+A valid Bearer token authenticates the request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Issue a token for the test user (this is what /login does internally
+once the user is authenticated):
+
+    >>> token = create_token(TEST_USER_ID)
+    >>> transaction.commit()
+    >>> isinstance(token, basestring) and len(token) > 0
+    True
+
+A fresh browser carrying that token in the ``Authorization: Bearer``
+header is authenticated by the JWT PAS plugin:
+
+    >>> is_authenticated(with_bearer(fresh_browser(), token))
+    True
+
+
+An invalid Bearer token does not authenticate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A garbage value cannot be decoded, so the request stays anonymous:
+
+    >>> is_authenticated(with_bearer(fresh_browser(), "not-a-real-token"))
+    False
+
+
+A token signed with the wrong secret does not authenticate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A well-formed JWT signed with a different secret fails signature
+verification:
+
+    >>> import jwt as pyjwt
+    >>> forged = pyjwt.encode(
+    ...     {"userid": TEST_USER_ID, "exp": timestamp(seconds=3600)},
+    ...     "wrong-secret", algorithm="HS256")
+    >>> is_authenticated(with_bearer(fresh_browser(), forged))
+    False
+
+
+An expired token does not authenticate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A token whose ``exp`` claim lies in the past is rejected by PyJWT:
+
+    >>> expired_token = create_token(TEST_USER_ID, exp=timestamp(seconds=-60))
+    >>> transaction.commit()
+    >>> is_authenticated(with_bearer(fresh_browser(), expired_token))
+    False
+
+
+Rotating the user's secret revokes existing tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After ``rotate_secret``, the previously-issued token no longer
+verifies:
+
+    >>> rotate_secret(TEST_USER_ID)
+    >>> transaction.commit()
+    >>> is_authenticated(with_bearer(fresh_browser(), token))
+    False
+
+A token issued after the rotation is accepted again:
+
+    >>> new_token = create_token(TEST_USER_ID)
+    >>> transaction.commit()
+    >>> is_authenticated(with_bearer(fresh_browser(), new_token))
+    True

--- a/src/senaite/jsonapi/tests/doctests/bearer.rst
+++ b/src/senaite/jsonapi/tests/doctests/bearer.rst
@@ -82,7 +82,7 @@ HTTP libraries, browser extensions, etc.) can use the
 ``X-JWT-Auth-Token`` fallback header instead:
 
     >>> fallback = fresh_browser()
-    >>> fallback.addHeader("X-JWT-Auth-Token", token)
+    >>> fallback.addHeader("X-JWT-Auth-Token", token.encode("ascii"))
     >>> is_authenticated(fallback)
     True
 

--- a/src/senaite/jsonapi/tests/doctests/login.rst
+++ b/src/senaite/jsonapi/tests/doctests/login.rst
@@ -73,6 +73,19 @@ not retained by ``browser.cookies``; the assertion below would only
 hold over HTTPS. Clients running on HTTP must therefore use the
 ``Authorization: Bearer`` header (covered next).
 
+The Set-Cookie header still carries the expected security attributes
+even when the browser drops the cookie itself:
+
+    >>> set_cookie = browser.headers.get("Set-Cookie") or ""
+    >>> "token=" in set_cookie
+    True
+    >>> "HttpOnly" in set_cookie
+    True
+    >>> "Secure" in set_cookie
+    True
+    >>> "SameSite=Lax" in set_cookie
+    True
+
 
 Authenticate with Authorization: Bearer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/senaite/jsonapi/tests/doctests/login.rst
+++ b/src/senaite/jsonapi/tests/doctests/login.rst
@@ -1,0 +1,148 @@
+JWT LOGIN
+---------
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t login
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> from base64 import b64encode
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.testing.zope import Browser
+    >>> from senaite.jsonapi.pas.plugin import create_token
+    >>> from senaite.jsonapi.pas.plugin import rotate_secret
+    >>> from senaite.jsonapi.pas.plugin import timestamp
+
+
+Functional Helpers:
+
+    >>> def fresh_browser():
+    ...     b = Browser(self.portal)
+    ...     b.addHeader("Accept-Language", "en-US")
+    ...     b.handleErrors = False
+    ...     return b
+
+    >>> def basic(b, userid, password):
+    ...     b.addHeader(
+    ...         "Authorization", "Basic {}:{}".format(userid, password))
+    ...     return b
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> portal_url = portal.absolute_url()
+    >>> api_url = "{}/@@API/senaite/v1".format(portal_url)
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+
+Issue a token via /login
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+An already-authenticated user calls /login and obtains a JWT in the
+response body. The setup helper ``self.getBrowser()`` returns a browser
+that has a Plone session cookie, so the request is authenticated by
+the cookie auth plugin before the route runs:
+
+    >>> browser = self.getBrowser()
+    >>> browser.open("{}/login".format(api_url))
+    >>> data = json.loads(browser.contents)
+    >>> data["items"][0]["authenticated"]
+    True
+
+    >>> token = data["token"]
+    >>> isinstance(token, basestring) and len(token) > 0
+    True
+
+    >>> data["expires"] > timestamp()
+    True
+
+The same response sets the JWT as an HttpOnly cookie:
+
+    >>> "token" in browser.cookies
+    True
+
+
+Authenticate with Authorization: Bearer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A fresh browser (no Plone cookie, no Basic auth) authenticated only
+with the Bearer token can access the auth-protected route:
+
+    >>> bearer = fresh_browser()
+    >>> bearer.addHeader("Authorization", "Bearer {}".format(token))
+    >>> bearer.open("{}/auth".format(api_url))
+    >>> "_runtime" in bearer.contents
+    True
+
+And `/users/current` returns the authenticated user:
+
+    >>> bearer.open("{}/users/current".format(api_url))
+    >>> info = json.loads(bearer.contents)
+    >>> info["items"][0]["authenticated"]
+    True
+
+
+An invalid Bearer token is rejected
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A bogus token must not authenticate the request:
+
+    >>> bogus = fresh_browser()
+    >>> bogus.addHeader("Authorization", "Bearer not-a-real-token")
+    >>> bogus.open("{}/auth".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 401: Unauthorized
+
+
+An expired token is rejected
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A token that has already expired is treated as anonymous and rejected
+by the auth route:
+
+    >>> expired_token = create_token(TEST_USER_ID, exp=timestamp(seconds=-60))
+    >>> transaction.commit()
+    >>> expired = fresh_browser()
+    >>> expired.addHeader("Authorization", "Bearer {}".format(expired_token))
+    >>> expired.open("{}/auth".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 401: Unauthorized
+
+
+Rotating the user's secret revokes existing tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After rotating, the previously-issued token no longer verifies:
+
+    >>> rotate_secret(TEST_USER_ID)
+    >>> transaction.commit()
+
+    >>> revoked = fresh_browser()
+    >>> revoked.addHeader("Authorization", "Bearer {}".format(token))
+    >>> revoked.open("{}/auth".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 401: Unauthorized
+
+A freshly issued token works again:
+
+    >>> new_token = create_token(TEST_USER_ID)
+    >>> transaction.commit()
+    >>> renewed = fresh_browser()
+    >>> renewed.addHeader("Authorization", "Bearer {}".format(new_token))
+    >>> renewed.open("{}/auth".format(api_url))
+    >>> "_runtime" in renewed.contents
+    True

--- a/src/senaite/jsonapi/tests/doctests/login.rst
+++ b/src/senaite/jsonapi/tests/doctests/login.rst
@@ -67,10 +67,11 @@ the cookie auth plugin before the route runs:
     >>> data["expires"] > timestamp()
     True
 
-The same response sets the JWT as an HttpOnly cookie:
-
-    >>> "token" in browser.cookies
-    True
+The response also sets the JWT as an HttpOnly, Secure cookie. The
+test browser drives the API over plain HTTP, so the Secure cookie is
+not retained by ``browser.cookies``; the assertion below would only
+hold over HTTPS. Clients running on HTTP must therefore use the
+``Authorization: Bearer`` header (covered next).
 
 
 Authenticate with Authorization: Bearer

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -187,7 +187,8 @@ def login(context, request):
     # it transparently
     request.response.setCookie(
         JWT_COOKIE_ID, token,
-        http_only=True, path="/", same_site="None", expires=expires,
+        http_only=True, secure=True, path="/", same_site="Lax",
+        expires=expires,
     )
 
     # Return the user info merged with the token payload

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -23,6 +23,10 @@ from plone import api as ploneapi
 from senaite.jsonapi import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import request as req
+from senaite.jsonapi.config import JWT_COOKIE_ID
+from senaite.jsonapi.config import JWT_TOKENS_TIMEOUT
+from senaite.jsonapi.pas.plugin import create_token
+from senaite.jsonapi.pas.plugin import timestamp
 from senaite.jsonapi.v1 import add_route
 from senaite.jsonapi.interfaces import IInfo
 from senaite.jsonapi.interfaces import IUsersFilter
@@ -141,34 +145,58 @@ def auth(context, request):
 def login(context, request):
     """ Login Route
 
-    Login route to authenticate a user against Plone.
+    Authenticates the user and issues a JSON Web Token (JWT). Two
+    authentication modes are supported:
+
+    1. HTTP Basic auth (header ``Authorization: Basic ...``): no body
+       fields are needed; the route just issues a token for the user
+       that was already authenticated by the PAS layer.
+    2. Form login: POST ``__ac_name`` and ``__ac_password`` as form
+       fields. The route logs the user in via the cookie auth plugin
+       and then issues the token.
+
+    The JWT is returned in the JSON body as ``token`` (with ``expires``
+    as a Unix timestamp) and is also set as the ``token`` HttpOnly
+    cookie so subsequent requests can be authenticated either via
+    ``Authorization: Bearer <token>`` or via the cookie.
     """
     # extract the data
     __ac_name = request.get("__ac_name", None)
     __ac_password = request.get("__ac_password", None)
 
-    logger.info("*** LOGIN %s ***" % __ac_name)
+    logger.info("*** LOGIN %s ***" % (__ac_name or "<basic>"))
 
-    if __ac_name is None:
-        api.fail(400, "__ac_name is missing")
-    if __ac_password is None:
-        api.fail(400, "__ac_password is missing")
-
-    acl_users = api.get_tool("acl_users")
-
-    # XXX hard coded
-    acl_users.credentials_cookie_auth.login()
-
-    # XXX admin user won't be logged in if I use this approach
-    # acl_users.login()
-    # response = request.response
-    # acl_users.updateCredentials(request, response, __ac_name, __ac_password)
+    # Form-based login path: log the user in via the cookie auth plugin.
+    # Basic-auth requests (and other PAS-authenticated requests) skip this
+    # block since the user is already authenticated by the time the route
+    # is dispatched.
+    if __ac_name is not None and __ac_password is not None:
+        acl_users = api.get_tool("acl_users")
+        # XXX hard coded
+        acl_users.credentials_cookie_auth.login()
 
     if api.is_anonymous():
         api.fail(401, "Invalid Credentials")
 
-    # return the JSON in the same format like the user route
-    return get(context, request, username=__ac_name)
+    # Issue a JWT for the now-authenticated user
+    userid = api.get_current_user().getId()
+    expires = timestamp(seconds=JWT_TOKENS_TIMEOUT)
+    token = create_token(userid, exp=expires)
+
+    # Set the token as an HttpOnly cookie so cookie-based clients can use
+    # it transparently
+    request.response.setCookie(
+        JWT_COOKIE_ID, token,
+        http_only=True, path="/", same_site="None", expires=expires,
+    )
+
+    # Return the user info merged with the token payload
+    info = get(context, request, username=userid) or {}
+    info.update({
+        "token": token,
+        "expires": expires,
+    })
+    return info
 
 
 @add_route("/logout", "senaite.jsonapi.v1.logout", methods=["GET"])
@@ -184,6 +212,12 @@ def logout(context, request):
 
     acl_users = api.get_tool("acl_users")
     acl_users.logout(request)
+
+    # Expire the JWT cookie on the client side. Note this does not
+    # invalidate the JWT itself — to revoke a token before its
+    # expiration, rotate the user's signing secret with
+    # ``senaite.jsonapi.pas.plugin.rotate_secret``.
+    request.response.expireCookie(JWT_COOKIE_ID, path="/")
 
     return {
         "url": api.url_for("senaite.jsonapi.v1.users"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adds Bearer token (JWT) authentication to SENAITE.JSONAPI via a dedicated PAS plugin, plus the GenericSetup install/uninstall plumbing needed to wire it into a Plone site from the Add-ons control panel.

## Current behavior before PR

- The only auth mechanisms exposed by senaite.jsonapi are HTTP Basic and the Plone session cookie.
- `/login` returns the user info but no token; clients must keep the session cookie alive for every subsequent request.
- There is no way to revoke an issued credential server-side without disabling the user.
- senaite.jsonapi has no GenericSetup profile at all and does not appear in the Add-ons control panel.

## Desired behavior after PR is merged

### JWT authentication

- New `JWTAuthenticationPlugin` PAS plugin (registered on top for `IExtractionPlugin` + `IAuthenticationPlugin`).
- Token is extracted, in this order, from:
  1. `Authorization: Bearer <token>` header
  2. `token` cookie (HttpOnly, Secure, SameSite=Lax)
  3. `X-JWT-Auth-Token` header (fallback for clients that cannot set the `Authorization` header)
- Each user gets their own signing secret, stored in an `OOBTree` annotation on the portal. `rotate_secret(userid)` invalidates every token issued for that user — the revocation primitive that was missing.
- `/login` now accepts either HTTP Basic or `__ac_name`/`__ac_password` form fields and returns `{token, expires, ...user info}`. The token is also set as an HttpOnly cookie (`Secure`, `SameSite=Lax`) so cookie-based clients keep working transparently over HTTPS. Over plain HTTP the cookie is dropped by the browser; clients must use the `Authorization: Bearer` header.
- `/logout` expires the cookie on the client; full server-side invalidation is done with `rotate_secret`.
- `pyjwt<2.0.0` pinned (Python 2.7 compatibility).

### Install / uninstall profile

- First GenericSetup profile for senaite.jsonapi: `profiles/default` registers the JWT PAS plugin in `acl_users` and moves it to the top of the extraction/authentication interfaces.
- `profiles/default/metadata.xml` declares `profile-senaite.core:default` as a dependency.
- New `profiles/uninstall` profile removes the PAS plugin from `acl_users` and clears the per-user key storage annotation.
- `INonInstallable` adapter (`HiddenProfiles`) hides the uninstall profile from the Add-ons panel so only *SENAITE JSONAPI* is listed as installable; the uninstall profile is applied automatically by the *Uninstall* button.
- Existing 2.6.x sites must install the add-on once from *Site Setup* -> *Add-ons*; the cookie and Basic auth paths keep working without it.

### Tests

Two new doctests under `src/senaite/jsonapi/tests/doctests/`:

- `bearer.rst` — covers extraction, valid/invalid/forged/expired tokens, secret rotation against the PAS plugin directly, and the `X-JWT-Auth-Token` fallback header.
- `login.rst` — exercises the full `/login` -> `/auth` -> `/users/current` flow with Bearer tokens, rejection of invalid/expired/revoked tokens, and asserts the `Set-Cookie` header carries `HttpOnly`, `Secure` and `SameSite=Lax`.

Run with:

```
bin/test test_doctests -t bearer
bin/test test_doctests -t login
```

### Documentation

- `docs/auth.rst` extended with a Bearer Token Authentication section, a "Try it" guide (DevTools console, curl, HTTPS reverse-proxy for the Secure cookie path, debug-shell revocation, REST clients), cookie-security notes, and an updated `/login` response example.
- `docs/changelog.rst` notes the install requirement for existing sites.

I confirm I have tested the PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008