### PR TITLE
Fix inherited schema fields missing for multi-schema Dexterity types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #89 Fix inherited schema fields missing for multi-schema Dexterity types
 - #87 Inject additional analyses fields
 - #85 Allow field projection
 - #81 Support second-level precision on searches against DateIndex

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -749,15 +749,8 @@ def get_fields(brain_or_object):
     # The portal object has no schema
     if is_root(obj):
         return {}
-    schema = get_schema(obj)
-    if is_dexterity_content(obj):
-        names = schema.names()
-        fields = map(lambda name: schema.get(name), names)
-        schema_fields = dict(zip(names, fields))
-        # update with behavior fields
-        schema_fields.update(get_behaviors(obj))
-        return schema_fields
-    return dict(zip(schema.keys(), schema.fields()))
+    # rely on core's api
+    return api.get_fields(obj)
 
 
 def get_field(brain_or_object, name, default=None):

--- a/src/senaite/jsonapi/dataproviders.py
+++ b/src/senaite/jsonapi/dataproviders.py
@@ -207,9 +207,8 @@ class DexterityDataProvider(Base):
         super(DexterityDataProvider, self).__init__(context)
 
         # get the behavior and schema fields from the data manager
-        schema = api.get_schema(context)
-        behaviors = api.get_behaviors(context)
-        self.keys = schema.names() + behaviors.keys()
+        fields = api.get_fields(context)
+        self.keys = fields.keys()
 
 
 class ATDataProvider(Base):
@@ -222,8 +221,8 @@ class ATDataProvider(Base):
         super(ATDataProvider, self).__init__(context)
 
         # get the schema fields from the data manager
-        schema = api.get_schema(context)
-        self.keys = schema.keys()
+        fields = api.get_fields(context)
+        self.keys = fields.keys()
 
 
 class AnalysisDataProvider(Base):

--- a/src/senaite/jsonapi/tests/doctests/dexterity_inherited_fields.rst
+++ b/src/senaite/jsonapi/tests/doctests/dexterity_inherited_fields.rst
@@ -1,0 +1,107 @@
+DEXTERITY INHERITED FIELDS
+--------------------------
+
+Regression test for multi-schema Dexterity types.
+
+When the searched object is a Dexterity (DX) type whose schema interface
+inherits from another schema interface, the fields declared by the *parent*
+schema must be returned too. The previous implementation relied on
+``schema.names()``, which only returns the fields declared directly on the
+interface (inherited fields require ``names(all=True)``), so inherited fields
+were silently dropped from the API response.
+
+``senaite.core.content.supplier.Supplier`` is a good example of a multi-schema
+DX type: its schema ``ISupplierSchema`` inherits from ``IOrganizationSchema``.
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t dexterity_inherited_fields
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+    >>> from bika.lims import api
+    >>> from senaite.jsonapi import api as japi
+
+Functional Helpers:
+
+    >>> def get(url):
+    ...     browser.open("{}/{}".format(api_url, url))
+    ...     return browser.contents
+
+Variables:
+
+    >>> portal = self.portal
+    >>> setup = portal.setup
+    >>> portal_url = portal.absolute_url()
+    >>> api_url = "{}/@@API/senaite/v1".format(portal_url)
+    >>> browser = self.getBrowser()
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+Create a Supplier (DX type with an inherited schema):
+
+    >>> supplier = api.create(setup.suppliers, "Supplier", Name="Naralabs")
+    >>> uid = api.get_uid(supplier)
+    >>> transaction.commit()
+
+
+The DX type is genuinely multi-schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The schema interface inherits from a parent schema interface:
+
+    >>> from senaite.core.content.supplier import ISupplierSchema
+    >>> from senaite.core.content.organization import IOrganizationSchema
+    >>> IOrganizationSchema in ISupplierSchema.__bases__
+    True
+
+``tax_number`` is declared by the *parent* ``IOrganizationSchema``, while
+``lab_account_number`` is declared *directly* on ``ISupplierSchema``:
+
+    >>> "tax_number" in IOrganizationSchema.names()
+    True
+    >>> "tax_number" in ISupplierSchema.names()
+    False
+    >>> "lab_account_number" in ISupplierSchema.names()
+    True
+
+
+Inherited fields are returned by get_fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The fields mapping must contain both the directly declared field and the
+inherited one:
+
+    >>> fields = japi.get_fields(supplier)
+    >>> "lab_account_number" in fields
+    True
+    >>> "tax_number" in fields
+    True
+
+``get_field`` resolves the inherited field too (it previously returned the
+default because the field was missing from the mapping):
+
+    >>> japi.get_field(supplier, "tax_number") is not None
+    True
+
+
+Inherited fields are present in the API response
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+End to end, fetching the object exposes the inherited field as a key:
+
+    >>> response = get(uid)
+    >>> data = json.loads(response)
+    >>> "lab_account_number" in data
+    True
+    >>> "tax_number" in data
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
When the object being serialized is a Dexterity (DX) content type whose schema interface inherits from another schema interface, only the fields declared *directly* on the type's own interface were returned. Fields declared by the parent interface(s) were silently dropped from the API response.

The root cause was the use of `schema.names()` in `get_fields`, which returns only the names declared directly on the interface — inherited fields require `names(all=True)`. `senaite.core`'s `api.get_fields` already resolves this correctly (it uses `plone.supermodel`'s `getFieldsInOrder`, which walks the interface bases, and also folds in behavior fields), so this PR delegates to it instead of re-implementing the field collection.

`senaite.core.content.supplier.Supplier` is a representative multi-schema DX type: its `ISupplierSchema` inherits from `IOrganizationSchema`.

## Current behavior before PR

For a multi-schema DX type, the JSON response (and `get_fields` / `get_field`) expose only the fields declared on the leaf schema interface. Inherited fields (e.g. `tax_number`, declared on the parent `IOrganizationSchema`) are missing, so they cannot be read, searched or projected through the API.

## Desired behavior after PR is merged

All schema fields are returned — those declared directly on the type's interface, those inherited from parent interfaces, and those contributed by assigned behaviors. `get_fields`, `get_field` and the `Dexterity`/`AT` data providers all derive their field set from a single source (`senaite.core`'s `api.get_fields`), keeping the field list and per-field lookups consistent.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
