### PR TITLE
Add DataGridFieldManager to fix UID reference validation in DataGrid fields

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #91 Add DataGridFieldManager to fix UID reference validation in DataGrid fields
 - #90 Fix JWT authentication security issues
 - #88 Add Bearer token (JWT) authentication via PAS plugin
 - #89 Fix inherited schema fields missing for multi-schema Dexterity types

--- a/src/senaite/jsonapi/configure.zcml
+++ b/src/senaite/jsonapi/configure.zcml
@@ -204,6 +204,11 @@
       factory=".fieldmanagers.DXUIDReferenceFieldManager"
       />
 
+  <!-- Adapter for DX DataGridField Field -->
+  <adapter
+      for="senaite.core.schema.interfaces.IDataGridField"
+      factory=".fieldmanagers.DataGridFieldManager"
+      />
 
   <!-- ZOPE SCHEMA FIELD MANAGERS
        Field level interface to get and set values and get a JSON compatible

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -24,12 +24,14 @@ import dateutil
 from AccessControl import Unauthorized
 from DateTime import DateTime
 from Products.Archetypes.utils import mapply
+from senaite.core.schema.uidreferencefield import UIDReferenceField
 from senaite.jsonapi import api
 from senaite.jsonapi import logger
 from senaite.jsonapi import underscore as u
 from senaite.jsonapi.interfaces import IFieldManager
 from zope import interface
 from zope.interface import implementer
+from zope.schema import getFields
 from zope.schema._bootstrapinterfaces import WrongContainedType
 from zope.schema._bootstrapinterfaces import WrongType
 
@@ -100,11 +102,6 @@ class DataGridFieldManager(ZopeSchemaFieldManager):
     interface.implements(IFieldManager)
 
     def _normalize_datagrid(self, value):
-        """UIDReferenceField sub-fields nested inside a DataGridRow always
-        require a list of native `str` UIDs - never a bare value, and
-        never `unicode` (which is what every JSON API request delivers,
-        regardless of what the client originally sent).
-        """
         schema = self.field.value_type.schema
 
         for row in value:
@@ -113,6 +110,8 @@ class DataGridFieldManager(ZopeSchemaFieldManager):
                     uid = row.get(name)
                     if not uid:
                         continue
+                    # UIDReferenceField sub-fields nested inside a DataGridRow
+                    # always require a list of native `str` UIDs
                     if isinstance(uid, list):
                         row[name] = [str(u) for u in uid]
                     else:

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -94,6 +94,42 @@ class ZopeSchemaFieldManager(object):
         return self.field.get(instance)
 
 
+class DataGridFieldManager(ZopeSchemaFieldManager):
+    """Adapter to get/set the value of DataGridField (grid/records) fields.
+ 
+    Kept entirely separate from ZopeSchemaFieldManager so that DataGrid-
+    specific normalization never affects any other field type.
+    """
+    interface.implements(IFieldManager)
+ 
+    def _normalize_datagrid(self, value):
+        """UIDReferenceField sub-fields nested inside a DataGridRow always
+        require a list of native `str` UIDs - never a bare value, and
+        never `unicode` (which is what every JSON API request delivers,
+        regardless of what the client originally sent).
+        """
+        schema = self.field.value_type.schema
+ 
+        for row in value:
+            for name, field in getFields(schema).items():
+                if isinstance(field, UIDReferenceField):
+                    uid = row.get(name)
+                    if not uid:
+                        continue
+                    if isinstance(uid, list):
+                        row[name] = [str(u) for u in uid]
+                    else:
+                        row[name] = [str(uid)]
+ 
+        return value
+ 
+    def set(self, instance, value, **kw):
+        """Set the value of the field
+        """
+        value = self._normalize_datagrid(value)
+        return self._set(instance, value, **kw)
+
+
 class DatetimeFieldManager(ZopeSchemaFieldManager):
     """Adapter to get/set the value of Datetime Fields
     """

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -95,13 +95,10 @@ class ZopeSchemaFieldManager(object):
 
 
 class DataGridFieldManager(ZopeSchemaFieldManager):
-    """Adapter to get/set the value of DataGridField (grid/records) fields.
- 
-    Kept entirely separate from ZopeSchemaFieldManager so that DataGrid-
-    specific normalization never affects any other field type.
+    """Adapter to get/set the value of DataGridField (grid/records) fields
     """
     interface.implements(IFieldManager)
- 
+
     def _normalize_datagrid(self, value):
         """UIDReferenceField sub-fields nested inside a DataGridRow always
         require a list of native `str` UIDs - never a bare value, and
@@ -109,7 +106,7 @@ class DataGridFieldManager(ZopeSchemaFieldManager):
         regardless of what the client originally sent).
         """
         schema = self.field.value_type.schema
- 
+
         for row in value:
             for name, field in getFields(schema).items():
                 if isinstance(field, UIDReferenceField):
@@ -120,9 +117,8 @@ class DataGridFieldManager(ZopeSchemaFieldManager):
                         row[name] = [str(u) for u in uid]
                     else:
                         row[name] = [str(uid)]
- 
         return value
- 
+
     def set(self, instance, value, **kw):
         """Set the value of the field
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`ZopeSchemaFieldManager` has no dedicated handling for `DataGridField`. When a grid row contains a `UIDReferenceField`, creating objects via the JSON API fails with `WrongContainedType`, since JSON always delivers unicode (not str) and grid-nested `UID` fields always expect a list, even when multi_valued=False.

## Current behavior before PR

```sh
WrongContainedType([WrongContainedType([WrongType(u'<uid>', <type 'str'>, '')], 'uid')], 'activities')
```

## Desired behavior after PR is merged

New `DataGridFieldManager(ZopeSchemaFieldManager)` normalizes UID sub-fields in each row (coerces to list of native str) before delegating to the existing _set().

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
