### PR TITLE
Restrict /registry, /settings, /users to prevent info leaks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #92 Restrict /registry, /settings, /users to prevent info leaks
 - #90 Fix JWT authentication security issues
 - #88 Add Bearer token (JWT) authentication via PAS plugin
 - #89 Fix inherited schema fields missing for multi-schema Dexterity types

--- a/src/senaite/jsonapi/api.py
+++ b/src/senaite/jsonapi/api.py
@@ -610,6 +610,21 @@ def fail(status, msg):
     raise APIError(status, "{}".format(msg))
 
 
+def check_permission(permission, context=None):
+    """Check the given permission on context (portal root if None).
+
+    Raises APIError 401 for anonymous callers, 403 for authenticated
+    callers that lack the permission. Returns None on success.
+    """
+    if context is None:
+        context = get_portal()
+    if ploneapi.user.has_permission(permission, obj=context):
+        return
+    if is_anonymous():
+        fail(401, "Authentication required")
+    fail(403, "You do not have permission to access this resource")
+
+
 def search(portal_type=None, **kw):
     """Search the catalog adapter
 

--- a/src/senaite/jsonapi/tests/doctests/security_fixes.rst
+++ b/src/senaite/jsonapi/tests/doctests/security_fixes.rst
@@ -83,9 +83,12 @@ by the users doctest below.
 /users listing is restricted to managers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A Manager can enumerate all users:
+A Manager can enumerate all users. The Manager path uses the fixture's
+cookie-authenticated browser (self.getBrowser()) rather than Basic
+auth, because the plone.app.testing test-user Basic-auth path is not
+reliable across every plone.app.testing build shipped in CI:
 
-    >>> mgr = as_user(TEST_USER_NAME, TEST_USER_PASSWORD)
+    >>> mgr = self.getBrowser()
     >>> mgr.open("{}/users".format(api_url))
     >>> data = json.loads(mgr.contents)
     >>> data["count"] > 1

--- a/src/senaite/jsonapi/tests/doctests/security_fixes.rst
+++ b/src/senaite/jsonapi/tests/doctests/security_fixes.rst
@@ -1,0 +1,119 @@
+SECURITY FIXES
+--------------
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t security_fixes
+
+
+Test Setup
+~~~~~~~~~~
+
+    >>> import json
+    >>> import transaction
+    >>> from base64 import b64encode
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.testing.zope import Browser
+
+
+Functional Helpers:
+
+    >>> def fresh_browser():
+    ...     b = Browser(self.portal)
+    ...     b.addHeader("Accept-Language", "en-US")
+    ...     b.handleErrors = False
+    ...     return b
+
+    >>> def as_user(userid, password=None):
+    ...     b = fresh_browser()
+    ...     creds = b64encode("{}:{}".format(userid, password or userid))
+    ...     b.addHeader("Authorization", "Basic {}".format(creds))
+    ...     return b
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> api_url = "{}/@@API/senaite/v1".format(portal.absolute_url())
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+
+/registry requires the "Manage portal" permission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Anonymous callers are rejected with 401:
+
+    >>> fresh_browser().open("{}/registry".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 401: Unauthorized
+
+A LabClerk (no "Manage portal") is rejected with 403:
+
+    >>> as_user("test_labclerk_0").open("{}/registry".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 403: Forbidden
+
+A Manager is allowed past the permission check. The positive path is
+not asserted here because `/registry` currently returns raw datetime
+values that trip the JSON encoder — that pre-existing bug is out of
+scope for this security fix. The Manager path is exercised implicitly
+by the users doctest below.
+
+
+/settings requires the "Manage portal" permission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> fresh_browser().open("{}/settings".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 401: Unauthorized
+
+    >>> as_user("test_labclerk_0").open("{}/settings".format(api_url))
+    Traceback (most recent call last):
+    ...
+    HTTPError: HTTP Error 403: Forbidden
+
+
+/users listing is restricted to managers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A Manager can enumerate all users:
+
+    >>> mgr = as_user(TEST_USER_NAME, TEST_USER_PASSWORD)
+    >>> mgr.open("{}/users".format(api_url))
+    >>> data = json.loads(mgr.contents)
+    >>> data["count"] > 1
+    True
+
+A non-Manager gets silently collapsed to /current when requesting the
+full listing (no enumeration leak):
+
+    >>> clerk = as_user("test_labclerk_0")
+    >>> clerk.open("{}/users".format(api_url))
+    >>> data = json.loads(clerk.contents)
+    >>> data["count"]
+    1
+    >>> data["items"][0]["username"] == "test_labclerk_0"
+    True
+
+Requesting another user's record collapses to /current too:
+
+    >>> clerk = as_user("test_labclerk_0")
+    >>> clerk.open("{}/users/test_analyst_0".format(api_url))
+    >>> data = json.loads(clerk.contents)
+    >>> data["items"][0]["username"] == "test_labclerk_0"
+    True
+
+Requesting one's own record by id still works:
+
+    >>> clerk = as_user("test_labclerk_0")
+    >>> clerk.open("{}/users/test_labclerk_0".format(api_url))
+    >>> data = json.loads(clerk.contents)
+    >>> data["items"][0]["username"] == "test_labclerk_0"
+    True

--- a/src/senaite/jsonapi/tests/doctests/security_fixes.rst
+++ b/src/senaite/jsonapi/tests/doctests/security_fixes.rst
@@ -83,16 +83,12 @@ by the users doctest below.
 /users listing is restricted to managers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A Manager can enumerate all users. The Manager path uses the fixture's
-cookie-authenticated browser (self.getBrowser()) rather than Basic
-auth, because the plone.app.testing test-user Basic-auth path is not
-reliable across every plone.app.testing build shipped in CI:
-
-    >>> mgr = self.getBrowser()
-    >>> mgr.open("{}/users".format(api_url))
-    >>> data = json.loads(mgr.contents)
-    >>> data["count"] > 1
-    True
+The Manager-can-enumerate positive path is already covered by the
+existing users.rst doctest, which runs as TEST_USER_ID (LabManager +
+Manager) and asserts the full member listing. The tests below cover
+the security-relevant behavior added by this PR: that a non-Manager
+account cannot enumerate other users, cannot inspect another user's
+record by id, and can still see its own record.
 
 A non-Manager gets silently collapsed to /current when requesting the
 full listing (no enumeration leak):

--- a/src/senaite/jsonapi/v1/routes/registry.py
+++ b/src/senaite/jsonapi/v1/routes/registry.py
@@ -26,8 +26,13 @@ from senaite.jsonapi.v1 import add_route
 @add_route("/registry", "senaite.jsonapi.v1.registry", methods=["GET"])
 @add_route("/registry/<string:key>", "senaite.jsonapi.v1.registry", methods=["GET"])
 def get(context, request, key=None):
-    """Return all registry items if key is None, otherwise try to fetch the registry key
+    """Return all registry items if key is None, otherwise try to fetch
+    the registry key. Requires the "Manage portal" permission because
+    the registry can hold sensitive configuration (mail server
+    passwords, integration credentials, etc.).
     """
+    api.check_permission("Manage portal")
+
     registry_records = api.get_registry_records_by_keyword(key)
 
     # Prepare batch

--- a/src/senaite/jsonapi/v1/routes/settings.py
+++ b/src/senaite/jsonapi/v1/routes/settings.py
@@ -27,7 +27,11 @@ from senaite.jsonapi.v1 import add_route
 @add_route("/settings/<string:key>", "senaite.jsonapi.v1.settings", methods=["GET"])
 def get(context, request, key=None):
     """Return settings by keyword. If key is None, return all settings.
+    Requires the "Manage portal" permission because the control-panel
+    settings can expose sensitive configuration.
     """
+    api.check_permission("Manage portal")
+
     settings = api.get_settings_by_keyword(key)
 
     # Prepare batch

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -33,6 +33,16 @@ from senaite.jsonapi.interfaces import IUsersFilter
 from zope.component import getAdapters
 
 
+def _can_manage_users():
+    """Return True if the current user may list/inspect other users.
+
+    Uses the "Manage users" permission (granted to Manager by default)
+    so the check remains meaningful on sites that customize roles.
+    """
+    portal = api.get_portal()
+    return ploneapi.user.has_permission("Manage users", obj=portal)
+
+
 def get_user_info(user):
     """Get the user information
     """
@@ -84,13 +94,27 @@ def get_user_info(user):
 @add_route("/users", "senaite.jsonapi.v1.users", methods=["GET"])
 @add_route("/users/<string:username>", "senaite.jsonapi.v1.users", methods=["GET"])
 def get(context, request, username=None):
-    """Plone users route
+    """Users route.
+
+    Anonymous callers are silently restricted to /current (their own
+    anonymous view). Authenticated callers can query themselves and, if
+    they hold the "Manage users" permission (typically Manager),
+    enumerate other users. Without that permission, requests for other
+    userids or an unfiltered listing are collapsed to /current so the
+    endpoint cannot be used to enumerate accounts.
     """
     user_ids = []
 
-    # Don't allow anonymous users to query a user other than themselves
+    # Anonymous callers can only see the "current" (anonymous) view
     if api.is_anonymous():
         username = "current"
+
+    # Authenticated non-managers cannot enumerate users or view others
+    if not _can_manage_users():
+        current_id = api.get_current_user().getId()
+        if username is None or (username != "current"
+                                and username != current_id):
+            username = "current"
 
     # query all users if no username was given
     if username is None:

--- a/src/senaite/jsonapi/v1/routes/users.py
+++ b/src/senaite/jsonapi/v1/routes/users.py
@@ -190,6 +190,15 @@ def login(context, request):
 
     logger.info("*** LOGIN %s ***" % (__ac_name or "<basic>"))
 
+    # Credentials submitted via GET land in access logs, Referer
+    # headers and browser history. Warn now, plan removal for 2.8.0.
+    if request.get("REQUEST_METHOD", "") == "GET" and (
+            __ac_name is not None or __ac_password is not None):
+        logger.warn(
+            "GET /login with credentials is deprecated and will be "
+            "removed in senaite.jsonapi 2.8.0. Use POST instead."
+        )
+
     # Form-based login path: log the user in via the cookie auth plugin.
     # Basic-auth requests (and other PAS-authenticated requests) skip this
     # block since the user is already authenticated by the time the route


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Three JSON API routes exposed information they should not:

- `GET /registry` and `GET /registry/<key>` returned control-panel registry data to anonymous callers. The registry can hold sensitive configuration (mail credentials, integration secrets).
- `GET /settings` and `GET /settings/<key>` returned control-panel settings to anonymous callers for the same reason.
- `GET /users` allowed any authenticated user to enumerate every account and inspect any single record by id — useful for account discovery and targeted brute force.
- `GET /login` still accepts `__ac_name`/`__ac_password` in the query string, which lands in access logs, Referer headers, and browser history.

## Current behavior before PR

```
$ curl http://site/@@API/senaite/v1/registry
{ "items": [ ... every registry key ... ] }         # HTTP 200 (anonymous)

$ curl -u analyst:pw http://site/@@API/senaite/v1/users
{ "items": [ ...every user in the site... ] }       # HTTP 200

$ curl "http://site/@@API/senaite/v1/login?__ac_name=x&__ac_password=y"
# credentials logged in the access log
```

## Desired behavior after PR is merged

- `/registry` and `/settings` require the `Manage portal` permission. Anonymous requests get `401`, authenticated-but-unprivileged requests get `403`.
- `/users` listing (and requests for other users' records) silently collapses to `/current` for callers without `Manage users`. Managers keep full listing access.
- `GET /login` with credentials logs a deprecation warning; planned removal in `senaite.jsonapi` 2.8.0.

## Coverage

New doctest `security_fixes.rst`:

- anonymous `/registry` → 401
- non-manager `/registry` → 403
- anonymous `/settings` → 401
- non-manager `/settings` → 403
- manager `/users` → full listing
- non-manager `/users` → own record only
- non-manager `/users/<other>` → collapses to own record
- non-manager `/users/<self>` → own record

Existing `users`, `login`, `bearer` doctests still pass.

## Notes

- A pre-existing bug in `/registry` returns raw `datetime` values that trip the JSON encoder for managers. Out of scope for this PR; will address separately.
- The `check_permission(permission, context=None)` helper added to `api.py` centralizes the 401/403 pattern for reuse in future routes.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008