### PR TITLE
Report the reason when object creation fails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #99 Report the reason when object creation fails
 - #98 Accept REST verbs PUT/PATCH/DELETE on the action route
 - #97 Extract create/update/delete helpers to api/mutation
 - #96 Add typed exception subclasses for the JSON API error envelope

--- a/src/senaite/jsonapi/api/mutation.py
+++ b/src/senaite/jsonapi/api/mutation.py
@@ -87,6 +87,7 @@ def create_items(portal_type=None, uid=None, endpoint=None, **kw):
     records = req.get_request_data()
 
     results = []
+    errors = []
     for record in records:
         if portal_type is None:
             portal_type = record.pop("portal_type", None)
@@ -111,9 +112,17 @@ def create_items(portal_type=None, uid=None, endpoint=None, **kw):
         except Exception as e:
             sp.rollback()
             logger.exception("Error while creating object: %s", e)
+            errors.append(str(e))
 
     if not results:
-        raise BadRequestError("No Objects could be created")
+        # Surface the underlying reason(s) -- e.g. missing required
+        # fields reported by the object's validation ({"field": "required
+        # field"}) -- instead of a generic failure, so the caller sees
+        # exactly what to fix.
+        detail = "; ".join(filter(None, errors))
+        raise BadRequestError(
+            "No objects could be created: {}".format(detail)
+            if detail else "No objects could be created")
 
     return make_items_for(results, endpoint=endpoint)
 


### PR DESCRIPTION
## What

`create_items` now includes the underlying error(s) in its response when nothing could be created, instead of the generic "No Objects could be created".

## Why

When an object failed to create, `create_items` caught the exception, logged it, and raised a generic `BadRequestError("No Objects could be created")` — discarding the actual reason. For example, creating an `AnalysisCategory` without its required `department` field produced only:

```
No Objects could be created
```

while the real cause was right there in the logs:

```
Error while creating object: {"department": "required field"}
```

Callers (including agents driving the API) had to dig through server logs to find out which required fields were missing.

## Change

`create_items` collects the per-object error messages and surfaces them in the raised error:

```
No objects could be created: {"department": "required field"}
```

The authoritative validation detail comes straight from SENAITE, so there is no duplicated list of required fields to maintain. Per-object savepoint rollback and the partial-success path (return whatever succeeded) are unchanged.

## Stacking

Stacked on top of #98 (`feature/rest-verbs`).