### PR TITLE
Normalize UID references through the field manager, not the setter

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #100 Normalize UID references through the field manager, not the setter
 - #99 Report the reason when object creation fails
 - #98 Accept REST verbs PUT/PATCH/DELETE on the action route
 - #97 Extract create/update/delete helpers to api/mutation

--- a/src/senaite/jsonapi/datamanagers.py
+++ b/src/senaite/jsonapi/datamanagers.py
@@ -31,6 +31,7 @@ from senaite.jsonapi import logger
 from senaite.jsonapi import api
 from senaite.jsonapi.interfaces import IDataManager
 from senaite.jsonapi.interfaces import IFieldManager
+from senaite.jsonapi.fieldmanagers import UIDReferenceFieldMixin
 
 
 class BaseDataManager(object):
@@ -225,22 +226,31 @@ class DexterityDataManager(BaseDataManager):
         if not self.can_write():
             raise Unauthorized("You are not allowed to modify this content")
 
-        # prioritize setters over fields
         setter = "".join(pt[:1].upper() + pt[1:] for pt in name.split("_"))
         setter = getattr(self.context, "set%s" % setter, None)
+
+        field = api.get_field(self.context, name)
+
+        # UID reference fields must be set via their field manager, which
+        # normalizes the value (resolves objects/paths and coerces UIDs
+        # to native str). A raw setter would store the value as given --
+        # e.g. a unicode UID from a JSON payload -- which then fails the
+        # field's ASCIILine value_type validation with WrongContainedType.
+        if field is not None:
+            fieldmanager = IFieldManager(field)
+            if isinstance(fieldmanager, UIDReferenceFieldMixin):
+                return fieldmanager.set(self.context, value, **kw)
+
+        # Otherwise prefer a content-type setter: it may carry side
+        # effects and also covers BBB properties without a schema field
+        # (e.g. Department.DepartmentID).
         if setter:
             return setter(value)
 
-        # fetch the field by name
-        field = api.get_field(self.context, name)
-
-        # bail out if we have no field
-        if not field:
+        # No setter: fall back to the field manager.
+        if field is None:
             return False
-
-        # call the field adapter and set the value
-        fieldmanager = IFieldManager(field)
-        return fieldmanager.set(self.context, value, **kw)
+        return IFieldManager(field).set(self.context, value, **kw)
 
     def json_data(self, name):
         """Get a JSON compatible structure for the named attribute


### PR DESCRIPTION
## What

`DexterityDataManager.set` now routes UID reference fields through their field manager instead of a content-type `set<Name>` mutator, so reference values are normalized before they are stored.

## Why

`DexterityDataManager.set` prioritized a `set<Name>` setter over the field manager. For a UID reference field (for example `Department.manager`), the auto-generated setter just calls the field mutator with the raw value, bypassing `UIDReferenceFieldMixin`'s normalization (resolve objects/paths, coerce UIDs to native `str`).

A UID posted as JSON arrives as unicode. Stored verbatim, it then fails the field's validation, because `UIDReferenceField` is a `List` whose `value_type` is `ASCIILine` (native `str` in py2):

```
POST .../Department/create  {"manager": "cc954ed8..."}
-> {"manager": "WrongContainedType"}
```

This blocked creating any object with a required single-valued DX UID reference through the API (Department, and therefore AnalysisCategory, ...).

## Change

In `DexterityDataManager.set`, skip the raw setter and use the field manager when the field manager is a `UIDReferenceFieldMixin` (AT or DX UID reference). The field manager normalizes the value and still ends at the field mutator, so no setter side effects are lost; all other fields keep using their setter.

## Verification

Reproduces with `Department.manager` via the JSON API before the change (`WrongContainedType`) and creates successfully after. Pairs with #99, which surfaced the underlying error in the first place.

## Stacking

Stacked on top of #99 (`feature/report-create-errors`).