### PR TITLE
Encode AT string field values to native str before validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #101 Encode AT string field values to native str before validation
 - #100 Normalize UID references through the field manager, not the setter
 - #99 Report the reason when object creation fails
 - #98 Accept REST verbs PUT/PATCH/DELETE on the action route

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -21,7 +21,9 @@
 import mimetypes
 
 import dateutil
+import six
 from AccessControl import Unauthorized
+from bika.lims import api as bika_api
 from DateTime import DateTime
 from Products.Archetypes.utils import mapply
 from senaite.core.schema.uidreferencefield import UIDReferenceField
@@ -303,6 +305,13 @@ class ATFieldManager(object):
         if not self.field.writeable(instance):
             raise Unauthorized("Field {} is read only."
                                .format(self.name))
+
+        # AT validators (isEmail, isDecimal, ...) expect a native str, but
+        # JSON values arrive as unicode and fail with "expected 'string'".
+        # Encode text values to utf-8 str; leave dicts/lists/other types
+        # untouched (records/datagrid/reference fields).
+        if isinstance(value, six.text_type):
+            value = bika_api.to_utf8(value)
 
         # validate the value
         error = self.field.validate(value, instance)

--- a/src/senaite/jsonapi/tests/doctests/create.rst
+++ b/src/senaite/jsonapi/tests/doctests/create.rst
@@ -311,6 +311,35 @@ Create an Analysis Service
     >>> ecoli.getCategory()
     <AnalysisCategory at /plone/setup/analysiscategories/analysiscategory-1>
 
+Create with a JSON body
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Field values from a JSON body arrive as unicode. AT fields with strict
+type-checking validators (`isDecimal`, `isEmail`, ...) must still accept
+them (they expect a native `str`):
+
+    >>> def create_json(data):
+    ...     browser.post(
+    ...         "{}/create".format(api_url), json.dumps(data),
+    ...         "application/json")
+    ...     response = json.loads(browser.contents)
+    ...     items = response.get("items")
+    ...     assert len(items) == 1, browser.contents
+    ...     return api.get_object(items[0]["uid"])
+
+    >>> data = {"portal_type": "AnalysisService",
+    ...         "parent_path": api.get_path(setup.bika_analysisservices),
+    ...         "title": "Nitrate",
+    ...         "Keyword": "NO3",
+    ...         "Price": u"12.50",
+    ...         "Category": api.get_uid(category)}
+    >>> nitrate = create_json(data)
+    >>> nitrate.getKeyword()
+    'NO3'
+    >>> nitrate.getPrice()
+    '12.50'
+
+
 Creating a Sample
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## What

`ATFieldManager._set` now utf-8-encodes unicode text values before the field validates them.

## Why

AT field validators (`isEmail`, `isDecimal`, ...) require a native `str`. Values from a JSON request body arrive as `unicode`, so they failed:

```
POST .../Client/update  {"EmailAddress": "info@example.com"}
-> Invalid value for field EmailAddress: Validation failed(isEmail):
   info@example.com of type <type 'unicode'>, expected 'string'

POST .../AnalysisService/update  {"Price": "12.50"}
-> Validation failed(isDecimal): 12.50 of type <type 'unicode'>, expected 'string'
```

So `EmailAddress`, `Price`, `VAT`, `DuplicateVariation` (and any AT field with a strict string validator) could not be set via the API. This mirrors the utf-8 handling `bika.lims.api.validate` already does on the read path.

## Change

Before `self.field.validate(...)`, encode text values with `bika.lims.api.to_utf8`, guarded by `isinstance(value, six.text_type)` so dicts/lists/numbers pass through untouched — records/datagrid/reference fields are unaffected. Native `str` (e.g. form submissions) is also untouched.

## Testing

New `create` doctest posts a **JSON body** (`Price: u"12.50"`) and asserts the service is created with `getPrice() == '12.50'`. Full suite green (31/0). The existing form-encoded doctests (native `str`) confirm no regression.

## Stacking

On top of #100.