### PR TITLE
Allow updating the setup configuration objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #103 Allow updating the setup configuration objects
 - #102 Support DX Duration (Timedelta) fields via a field manager
 - #101 Encode AT string field values to native str before validation
 - #100 Normalize UID references through the field manager, not the setter

--- a/src/senaite/jsonapi/api/mutation.py
+++ b/src/senaite/jsonapi/api/mutation.py
@@ -392,23 +392,40 @@ def is_creation_allowed(portal_type, container):
     return True
 
 
+def is_setup(obj):
+    """True if `obj` is one of the setup config singletons.
+
+    These are the AT `bika_setup` and the DX `senaite_setup` objects
+    that carry site-wide configuration (self verification, ID formatting,
+    ...). They live directly at the portal root.
+    """
+    setups = [bika_api.get_setup(), bika_api.get_senaite_setup()]
+    return any(obj == setup for setup in setups if setup is not None)
+
+
 def is_update_allowed(obj):
     """True if `obj` may be updated.
 
     Same denylist as `is_creation_allowed` (portal, bika_setup,
     senaite_setup), applied to the object's parent, plus an optional
     `IUpdate` adapter's opinion.
+
+    The setup config singletons themselves are an exception: they hold
+    site-wide settings and are meant to be updated, even though they sit
+    at the portal root (which the parent check below would otherwise
+    refuse). Only their children stay read-only.
     """
     if bika_api.is_portal(obj):
         return False
 
-    parent = bika_api.get_parent(obj)
-    if bika_api.is_portal(parent):
-        return False
-    if parent == bika_api.get_setup():
-        return False
-    if parent == bika_api.get_senaite_setup():
-        return False
+    if not is_setup(obj):
+        parent = bika_api.get_parent(obj)
+        if bika_api.is_portal(parent):
+            return False
+        if parent == bika_api.get_setup():
+            return False
+        if parent == bika_api.get_senaite_setup():
+            return False
 
     adapter = queryAdapter(obj, IUpdate)
     if adapter:


### PR DESCRIPTION
## Description

`is_update_allowed()` refuses any object whose parent is the portal root. That denylist also catches the setup configuration singletons — the AT `bika_setup` and the DX `senaite_setup` — which sit directly under the portal. As a result, site-wide settings stored on those objects (for example `SelfVerificationEnabled`) cannot be changed through the JSON API at all, even by a user who holds the required permission.

This PR adds an `is_setup()` helper and treats the two setup singletons as an explicit exception: the objects themselves become updatable, while their children stay read-only (the existing parent-based checks still apply to everything else). Authorization is unchanged — the `ModifyPortalContent` permission check in the data manager still gates every write — so only privileged users can update the setup config.

Stacked on #102.

## Current behavior before PR

Updating the setup config object returns `Update of /<site>/bika_setup is not allowed` (likewise for the DX `senaite_setup`), so settings such as self-verification cannot be toggled via the API.

## Desired behavior after PR is merged

The setup configuration singletons can be updated through the API (subject to the usual permission check), while objects contained in the setup folders remain read-only.