### PR TITLE
Fix Analyses field ignoring a plain list of analysis service UIDs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #104 Fix Analyses field ignoring a plain list of analysis service UIDs
 - #103 Allow updating the setup configuration objects
 - #102 Support DX Duration (Timedelta) fields via a field manager
 - #101 Encode AT string field values to native str before validation

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -678,10 +678,10 @@ class ARAnalysesFieldManager(ATFieldManager):
             uid = None
             if isinstance(item, dict):
                 uid = item.get("uid")
-            if api.is_uid(value):
+            elif api.is_uid(item):
                 uid = item
             if uid is None:
-                logger.warn("Could extract UID of value")
+                logger.warn("Could not extract UID from value %r", item)
                 continue
             uids.append(uid)
 


### PR DESCRIPTION
## Description

`ARAnalysesFieldManager.set` accepts either a single UID, a list of `{"uid": ...}` dicts, or a list of UID strings. The UID-string branch was guarded by `if api.is_uid(value)`, which tests the whole `value` (a list) instead of the current `item`. A list is never a UID, so every plain UID string fell through, no UIDs were collected, and the Analyses field was set to empty -- surfacing as `Analyses erfordert eine Eingabe` / `Invalid value for field Analyses`.

The fix checks `item` (and makes the two branches mutually exclusive). A list of analysis service UID strings now sets the analyses as expected; the dict form keeps working.

## Current behavior before PR

`update`/`create` on an AnalysisRequest with `{"Analyses": ["<uid>", "<uid>"]}` fails with a required-field error, because the field manager silently discards every UID.

## Desired behavior after PR is merged

Both forms work: a plain list of UID strings (`["<uid>", ...]`) and a list of dicts (`[{"uid": "<uid>"}, ...]`).

Stacked on #103.