### PR TITLE
Fix single-valued UID reference fields not settable through the JSON API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #106 Fix single-valued UID reference fields not settable through the JSON API
 - #94 Extract registry and settings helpers to api/settings
 - #93 Convert api module into a package and extract user helpers
 - #92 Restrict /registry, /settings, /users to prevent info leaks

--- a/src/senaite/jsonapi/fieldmanagers.py
+++ b/src/senaite/jsonapi/fieldmanagers.py
@@ -664,14 +664,18 @@ class UIDReferenceFieldMixin(object):
             elif api.is_path(v):
                 refs.append(api.get_object_by_path(v))
 
-        # Handle non multi valued fields
+        # convert all references to UIDs
+        refs = [str(api.get_uid(ref)) for ref in refs if ref]
+
+        # Single valued fields expect a scalar value, not a list. Passing a
+        # list makes the field validator of e.g. an AT UIDReferenceField
+        # reject the value with "[...] is not supported", so unwrap it here
+        # (None clears the reference). Multi valued fields keep the list.
         if not self.multi_valued:
             if len(refs) > 1:
                 raise ValueError("Multiple values given for single valued "
                                  "field {}".format(repr(self.field)))
-
-        # convert all references to UIDs
-        refs = [str(api.get_uid(ref)) for ref in refs if ref]
+            refs = refs[0] if refs else None
 
         return self._set(instance, refs, **kw)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`UIDReferenceFieldMixin.set` always forwards the resolved references to the field setter as a **list**, even when the field is single-valued. AT `UIDReferenceField` validators reject a list value with `[...] is not supported`, so assigning a single-valued reference through `@@API/senaite/v1/update` (or `create`) fails — for example a Sample's `Specification`, `Batch`, `SamplePoint` or `Template`.

The classic `ReferenceFieldManager` already unwraps single-valued fields to a scalar; the UID reference mixin (used by both the AT and DX UID reference field managers) does not.

## Current behavior before PR

Updating a single-valued UID reference field fails:

```
POST @@API/senaite/v1/update/<sample-uid>
{"Specification": "<spec-uid>"}

-> "['<spec-uid>'] is not supported."
```

The same happens with `{"Specification": {"uid": "<spec-uid>"}}`, because the value still reaches the field validator wrapped in a list.

## Desired behavior after PR is merged

The reference is assigned. Non multi-valued fields receive a scalar UID (or `None` to clear); multi-valued fields keep the list, unchanged. DX `UIDReferenceField.set` already normalizes via `to_list`, so scalars are accepted there too — the change is safe for both field managers.

--

Reproduced against a live 2.x instance (assigning a Sample `Specification`). The fix mirrors the single-valued handling in `ReferenceFieldManager`.

I confirm I have coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008