### PR TITLE
Validate only the submitted fields on update

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #107 Validate only the submitted fields on update
 - #106 Fix single-valued UID reference fields not settable through the JSON API
 - #94 Extract registry and settings helpers to api/settings
 - #93 Convert api module into a package and extract user helpers

--- a/src/senaite/jsonapi/api/__init__.py
+++ b/src/senaite/jsonapi/api/__init__.py
@@ -199,7 +199,7 @@ def update_items(portal_type=None, uid=None, endpoint=None, **kw):
         if not is_update_allowed(obj):
             fail(401, "Update of {} is not allowed".format(api.get_path(obj)))
 
-        obj = update_object_with_data(obj, record)
+        obj = update_object_with_data(obj, record, partial=True)
         return make_items_for([obj], endpoint=endpoint)
 
     # no uid -> go through the record items
@@ -216,7 +216,7 @@ def update_items(portal_type=None, uid=None, endpoint=None, **kw):
             fail(401, "Update of {} is not allowed".format(api.get_path(obj)))
 
         # update the object with the given record data
-        obj = update_object_with_data(obj, record)
+        obj = update_object_with_data(obj, record, partial=True)
         results.append(obj)
 
     if not results:
@@ -1427,13 +1427,16 @@ def create_analysisrequest(container, **data):
     return create_ar(container, request, data)
 
 
-def update_object_with_data(content, record):
+def update_object_with_data(content, record, partial=False):
     """Update the content with the record data
 
     :param content: A single folderish catalog brain or content object
     :type content: ATContentType/DexterityContentType/CatalogBrain
     :param record: The data to update
     :type record: dict
+    :param partial: When True (update route), only validate the submitted
+        fields. When False (creation), validate the whole object.
+    :type partial: bool
     :returns: The updated content object
     :rtype: object
     :raises:
@@ -1480,10 +1483,15 @@ def update_object_with_data(content, record):
 
             logger.debug("update_object_with_data::field %r updated", k)
 
-    # Validate the entire content object
-    invalid = api.validate(content)
-    if invalid:
-        fail(400, u.to_json(invalid))
+    # Validate the object. On a partial update the field managers already
+    # validated each submitted field on set, so a second whole-object
+    # validation only re-checks untouched fields, which can spuriously fail
+    # on a stored legacy value or a Dexterity behavior invariant. Skip it for
+    # partial updates; creation still validates the full object (see #66).
+    if not partial:
+        invalid = api.validate(content)
+        if invalid:
+            fail(400, u.to_json(invalid))
 
     # do a wf transition
     if record.get("transition", None):

--- a/src/senaite/jsonapi/tests/doctests/update.rst
+++ b/src/senaite/jsonapi/tests/doctests/update.rst
@@ -192,3 +192,40 @@ We cannot update the `id` of an object:
     >>> obj = get_item_object(response)
     >>> api.get_id(obj) == original_id
     True
+
+
+Partial validation on update
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An update only validates the fields that were submitted. Fields left untouched
+are not re-validated, so a pre-existing problem on another field does not block
+an unrelated update.
+
+    >>> data = {"portal_type": "Client",
+    ...         "parent_path": api.get_path(clients),
+    ...         "title": "Dolphin Corp",
+    ...         "ClientID": "DC"}
+    >>> client4 = create(data)
+
+Clear its required `ClientID` field, bypassing the API so the stored object no
+longer passes a full validation:
+
+    >>> client4.setClientID("")
+    >>> transaction.commit()
+
+Updating a different field still succeeds (the empty `ClientID` is not
+re-validated):
+
+    >>> data = {"uid": api.get_uid(client4), "title": "Dolphin Ltd"}
+    >>> response = post("update", data)
+    >>> obj = get_item_object(response)
+    >>> obj.Title()
+    'Dolphin Ltd'
+
+But submitting the offending field itself is still validated and rejected:
+
+    >>> data = {"uid": api.get_uid(client4), "ClientID": ""}
+    >>> post("update", data)
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 400: Bad Request


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`update_object_with_data` re-validates the whole object after applying the record. The field managers already validate each submitted field on `set`, so this second pass only re-checks fields the caller never touched, and it fails when one of them no longer passes a full validation: an Archetypes field holding a stored legacy value, or a Dexterity behavior invariant such as `IExcludeFromNavigationDefault`. In practice this blocks partial updates to setup objects (for example toggling a single `bika_setup` flag, or setting a Sample's `Specification`), even though the submitted field itself is valid.

This skips the redundant whole-object validation on the update route. Each submitted field is still validated on `set` (so invalid input is still rejected), while creation keeps validating the full object, preserving the behavior added in #66.

## Current behavior before PR

A partial update (`POST update/<uid>` with a single field) runs a full-object validation and can return `400` with errors for untouched fields, or fail on a behavior invariant.

## Desired behavior after PR is merged

The update only validates the fields that were submitted; unrelated untouched fields are left alone. Submitting an invalid field is still rejected. Covered by a new `Partial validation on update` section in `update.rst`.

--
I confirm I have coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008