### PR TITLE
Add a partition operation endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
    applied. Uninstalling from the same panel removes the PAS plugin
    and the per-user JWT signing secrets.
 
+- #109 Add a partition operation endpoint
 - #94 Extract registry and settings helpers to api/settings
 - #93 Convert api module into a package and extract user helpers
 - #92 Restrict /registry, /settings, /users to prevent info leaks

--- a/src/senaite/jsonapi/tests/doctests/partition.rst
+++ b/src/senaite/jsonapi/tests/doctests/partition.rst
@@ -86,6 +86,29 @@ The new partition points back to the primary sample:
     True
 
 
+Detach, reattach and publish
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Only *creating* a partition needs a dedicated endpoint, because it takes
+parameters (which analyses, sample type, container). The rest of the
+partition lifecycle are plain workflow transitions, so they go through the
+standard update route with the `transition` key (see the UPDATE doctest for
+the mechanism):
+
+Detach a partition (it then behaves like a primary sample and carries the
+`IDetachedPartition` marker)::
+
+    POST update {"uid": "<partition uid>", "transition": "detach"}
+
+Reattach it to its original primary sample::
+
+    POST update {"uid": "<partition uid>", "transition": "reattach"}
+
+Publish a verified sample::
+
+    POST update {"uid": "<verified sample uid>", "transition": "publish"}
+
+
 Multiple partitions in one call
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/senaite/jsonapi/tests/doctests/partition.rst
+++ b/src/senaite/jsonapi/tests/doctests/partition.rst
@@ -1,0 +1,114 @@
+PARTITION
+---------
+
+The partition operation creates aliquots of a received sample, moving the
+selected analyses into the new partition.
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t partition
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed Imports:
+
+    >>> import json
+    >>> import transaction
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+
+Functional Helpers:
+
+    >>> def post_json(url, data):
+    ...     url = "{}/{}".format(api_url, url)
+    ...     browser.post(url, json.dumps(data), "application/json")
+    ...     return browser.contents
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bika_setup = portal.bika_setup
+    >>> api_url = "{}/@@API/senaite/v1".format(portal.absolute_url())
+    >>> browser = self.getBrowser()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> setRoles(portal, TEST_USER_ID, ["Manager", "LabManager"])
+    >>> transaction.commit()
+
+Create the required setup content and a primary sample:
+
+    >>> clients = portal.clients
+    >>> client = api.create(clients, "Client", Name="ACME", ClientID="A")
+    >>> contact = api.create(client, "Contact", Firstname="John",
+    ...                      Surname="Doe")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType",
+    ...                         Prefix="water", MinimumVolume="100 ml")
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory",
+    ...                       title="Water")
+    >>> service = api.create(bika_setup.bika_analysisservices,
+    ...                      "AnalysisService", title="PH", ShortTitle="ph",
+    ...                      Category=category, Keyword="PH")
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SamplingDate": date_now,
+    ...     "DateSampled": date_now,
+    ...     "SampleType": sampletype.UID(),
+    ... }
+    >>> sample = create_analysisrequest(client, request, values,
+    ...                                 [service.UID()])
+    >>> transaction.commit()
+
+
+Create a partition
+~~~~~~~~~~~~~~~~~~~
+
+    >>> analyses = [api.get_uid(an)
+    ...             for an in sample.getAnalyses(full_objects=True)]
+    >>> data = {"uid": api.get_uid(sample), "analyses": analyses}
+    >>> response = post_json("partition", data)
+    >>> result = json.loads(response)
+    >>> result["count"]
+    1
+
+The new partition points back to the primary sample:
+
+    >>> partition = api.get_object(result["items"][0]["uid"])
+    >>> primary = partition.getParentAnalysisRequest()
+    >>> api.get_uid(primary) == api.get_uid(sample)
+    True
+
+
+Multiple partitions in one call
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> data = {"uid": api.get_uid(sample),
+    ...         "partitions": [{"analyses": []}, {"analyses": []}]}
+    >>> response = post_json("partition", data)
+    >>> json.loads(response)["count"]
+    2
+
+
+Errors
+~~~~~~
+
+A missing primary uid is rejected:
+
+    >>> post_json("partition", {"analyses": []})
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 400: Bad Request
+
+An unknown primary uid returns a 404:
+
+    >>> post_json("partition", {"uid": "no-such-uid"})
+    Traceback (most recent call last):
+    [...]
+    HTTPError: HTTP Error 404: Not Found

--- a/src/senaite/jsonapi/v1/routes/operations.py
+++ b/src/senaite/jsonapi/v1/routes/operations.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.JSONAPI.
+#
+# SENAITE.JSONAPI is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2017-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims.utils.analysisrequest import create_partition
+from senaite.jsonapi import api
+from senaite.jsonapi import request as req
+from senaite.jsonapi.api import fail
+from senaite.jsonapi.api import make_items_for
+from senaite.jsonapi.v1 import add_route
+
+# keys of a partition spec that are not passed straight to create_partition
+PARTITION_KWARGS = ("analyses", "sample_type", "container", "preservation",
+                    "internal_use")
+
+
+def create_one_partition(primary_uid, spec, request):
+    """Create a single partition of the primary sample
+
+    :param primary_uid: UID of the primary (root) sample
+    :param spec: mapping with the partition specific values
+    :param request: the current request object
+    :returns: the new partition sample
+    """
+    kwargs = {
+        "request": request,
+        "analysis_request": primary_uid,
+        "analyses": spec.get("analyses", []),
+        "sample_type": spec.get("sample_type"),
+        "container": spec.get("container"),
+        "preservation": spec.get("preservation"),
+    }
+    # only override the core default when the caller is explicit
+    if "internal_use" in spec:
+        kwargs["internal_use"] = spec.get("internal_use")
+    return create_partition(**kwargs)
+
+
+@add_route("/partition", "senaite.jsonapi.v1.partition", methods=["POST"])
+def partition(context, request):
+    """Create one or more partitions (aliquots) of a received sample
+
+    POST body::
+
+        {"uid": "<primary sample uid>",
+         "partitions": [
+            {"analyses": ["<analysis uid>", ...],
+             "sample_type": "<uid>",     # optional, defaults to the primary
+             "container": "<uid>",       # optional
+             "preservation": "<uid>",    # optional
+             "internal_use": false},     # optional
+            ...
+         ]}
+
+    A single partition may be given inline without the `partitions` wrapper::
+
+        {"uid": "<primary sample uid>", "analyses": ["<analysis uid>", ...]}
+
+    Creating a partition without analyses is allowed; analyses can be added
+    later. The selected analyses are moved from the primary into the
+    partition.
+    """
+    req.disable_csrf_protection()
+
+    records = req.get_request_data()
+    created = []
+
+    for record in records:
+        primary_uid = record.get("uid")
+        if not primary_uid:
+            fail(400, "A primary sample 'uid' is required")
+        if api.get_object_by_uid(primary_uid, None) is None:
+            fail(404, "No sample found for uid '{}'".format(primary_uid))
+
+        specs = record.get("partitions")
+        if not specs:
+            # treat the record itself as a single partition spec
+            specs = [record]
+
+        for spec in specs:
+            created.append(create_one_partition(primary_uid, spec, request))
+
+    if not created:
+        fail(400, "No partitions could be created")
+
+    items = make_items_for(created)
+    return {
+        "count": len(items),
+        "items": items,
+        "url": api.url_for("senaite.jsonapi.v1.partition"),
+    }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Partitioning a sample (creating aliquots that carry a subset of the analyses) is only reachable through the `partition_magic` browser view, which is POST driven and cannot be invoked from the JSON API. This adds a dedicated operation route.

`POST /senaite/v1/partition`

```json
{"uid": "<primary sample uid>",
 "partitions": [
   {"analyses": ["<analysis uid>", ...],
    "sample_type": "<uid>",     // optional, defaults to the primary
    "container": "<uid>",       // optional
    "preservation": "<uid>",    // optional
    "internal_use": false},     // optional
   ...
 ]}
```

A single partition can also be given inline without the `partitions` wrapper: `{"uid": "<primary uid>", "analyses": [...]}`. Creating a partition without analyses is allowed (analyses can be added later). The route wraps the core `create_partition` helper, so the behavior matches the UI.

It is exposed as a **dedicated operation route** rather than an `IUpdate` adapter on `AnalysisRequest`. An `IUpdate` adapter would route every Sample update through custom code, and `AnalysisRequest` is the most frequently updated type in the system, so a dedicated endpoint keeps the blast radius small and the operation explicit.

## Current behavior before PR

No way to create partitions through the API.

## Desired behavior after PR is merged

The route above creates one or more partitions and returns them, covered by a new `partition.rst` doctest.

--
I confirm I have coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008